### PR TITLE
feat: add Codex and OpenCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Structured Coding Library for Animal Advocacy
 
-Ready-to-use instruction file sets for 12 AI coding tools, designed for anyone building software for animal advocacy and liberation. Each tool directory is self-contained: copy it into your project root and your AI assistant immediately understands advocacy-domain constraints, security threat models, testing standards, and process workflows. No external dependencies, no shared config, no setup beyond copying files.
+Ready-to-use instruction file sets for 14 AI coding tools, designed for anyone building software for animal advocacy and liberation. Each tool directory is self-contained: copy it into your project root and your AI assistant immediately understands advocacy-domain constraints, security threat models, testing standards, and process workflows. No external dependencies, no shared config, no setup beyond copying files.
 
 ---
 
@@ -9,10 +9,16 @@ Ready-to-use instruction file sets for 12 AI coding tools, designed for anyone b
 Pick your tool. Copy the files into your project root.
 
 ```bash
+# Codex
+cp codex/AGENTS.md your-project/
+
 # Claude Code
 cp claude-code/CLAUDE.md your-project/
 cp claude-code/hooks-template.md your-project/
 cp -r claude-code/.claude your-project/
+
+# OpenCode
+cp opencode/AGENTS.md your-project/
 
 # Cursor
 cp cursor/.cursorrules your-project/
@@ -56,7 +62,9 @@ cp agents-md/AGENTS.md your-project/
 
 | Tool | Directory | Files | Format Notes |
 |------|-----------|------:|--------------|
-| Claude Code | `claude-code/` | 15 | CLAUDE.md + 7 scoped rules + 6 skills + hooks template |
+| Codex | `codex/` | 2 | AGENTS.md + README for Codex CLI, IDE, and GitHub-connected tasks |
+| Claude Code | `claude-code/` | 16 | CLAUDE.md + 8 scoped rules + 6 skills + hooks template |
+| OpenCode | `opencode/` | 2 | Native AGENTS.md + README, with optional `opencode.json` instruction layering |
 | Cursor | `cursor/` | 14 | .cursorrules + 13 .mdc files with 4 activation modes |
 | GitHub Copilot | `github-copilot/` | 22 | copilot-instructions.md + 7 instructions + 6 prompts + 2 chat modes + 6 skills |
 | Windsurf | `windsurf/` | 14 | 14 .md files in .windsurf/rules/ with 4 trigger types, within 6K/12K char limits |
@@ -68,7 +76,7 @@ cp agents-md/AGENTS.md your-project/
 | Gemini CLI | `gemini-cli/` | 1 | Single GEMINI.md with all content as sections |
 | JetBrains / Junie | `jetbrains-junie/` | 1 | Single .junie/guidelines.md, always loaded |
 | AGENTS.md | `agents-md/` | 1 | Single vendor-neutral file, supported by 20+ tools |
-| **Total** | | **137** | |
+| **Total** | | **142** | |
 
 ---
 
@@ -111,9 +119,13 @@ For Claude Code specifically, see `hooks-template.md` for setting up determinist
 
 ---
 
-## The 12 Tools
+## The 14 Tools
+
+**Codex** -- `AGENTS.md` at project root. Works for local Codex sessions and GitHub-connected Codex tasks. Best fit when you want one shared instruction file that covers execution discipline, approvals, verification, and advocacy-domain constraints.
 
 **Claude Code** -- `CLAUDE.md` at project root (under 60 lines), scoped rules in `.claude/rules/` with optional `paths:` frontmatter for file-targeted activation, process skills in `.claude/skills/` with YAML frontmatter. Supports hooks for deterministic enforcement of formatting, linting, and security scanning.
+
+**OpenCode** -- `AGENTS.md` at project root using OpenCode's native rules format. Additional modular guidance can be layered through `opencode.json` `instructions`, but the core project contract lives in the committed root file.
 
 **Cursor** -- `.cursorrules` at project root (always loaded), scoped rules in `.cursor/rules/*.mdc` using MDC format with four activation modes: Always Apply, Auto Attached (glob-triggered), Agent Requested (description-triggered), and Manual (user invokes with @).
 
@@ -141,4 +153,4 @@ For Claude Code specifically, see `hooks-template.md` for setting up determinist
 
 ## Source Material
 
-The content across all 12 tool sets was derived from a knowledge base covering: empirical research on AI-assisted development (code quality metrics, comprehension effects, failure patterns), software design principles (Ousterhout, Feathers, DDD), testing strategy (mutation testing, property-based testing, contract testing), git workflow for AI-generated code, and operational security for the animal advocacy domain. Each tool's content was independently authored to maximize use of its native format and activation mechanisms -- this is not a template applied 12 times.
+The content across all 14 tool sets was derived from a knowledge base covering: empirical research on AI-assisted development (code quality metrics, comprehension effects, failure patterns), software design principles (Ousterhout, Feathers, DDD), testing strategy (mutation testing, property-based testing, contract testing), git workflow for AI-generated code, and operational security for the animal advocacy domain. Each tool's content was independently authored to maximize use of its native format and activation mechanisms -- this is not a template applied 14 times.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -1,0 +1,179 @@
+# AGENTS.md — Codex Instructions
+
+This file is for OpenAI Codex. Commit it at the project root so Codex CLI, IDE integrations, and GitHub-connected Codex tasks all operate with the same project context.
+
+---
+
+# Project Identity
+
+This is an animal advocacy and liberation platform. The domain is high-risk: investigation data is subpoena-target evidence, activists face legal prosecution, and operational mistakes can endanger both people and animals. Treat this as advocacy infrastructure, not as a generic SaaS application with a mission statement layered on top.
+
+Primary users include investigators, campaign organizers, coalition partners, legal defense teams, and sanctuary operators. They do not share the same threat model, so design decisions must preserve clear operational boundaries.
+
+---
+
+# Codex Operating Notes
+
+- Keep patches small, explicit, and reviewable.
+- Read existing code before editing; use fast search to avoid duplicate logic.
+- Ask approval before destructive commands, network access, git pushes, or writes outside the current workspace.
+- Run the relevant test subset before finishing; if the repo has no tests, say so explicitly and verify structure another way.
+- For GitHub tasks, report changed files, verification status, blockers, and residual risk.
+- Keep this file self-contained. If the project adds deeper standards elsewhere, load them lazily when they are relevant to the task.
+
+---
+
+# Workflow
+
+Read before writing. Plan before code. Verify after changes. For any non-trivial task:
+
+1. Read the relevant code and identify the affected bounded context.
+2. Write a short specification: expected behavior, inputs, outputs, failure modes, and safety requirements.
+3. Break the work into small subtasks.
+4. Implement one subtask at a time.
+5. Run tests or equivalent verification after each meaningful change.
+
+Two-failure rule: after two failed fix attempts on the same problem, stop and re-approach with a better plan instead of compounding bad edits.
+
+Comprehension rule: do not ship code you cannot explain. Generate, understand, verify, then commit.
+
+---
+
+# Hard Constraints
+
+- NEVER log, store, or transmit activist personally identifiable information.
+- NEVER send sensitive advocacy data to external APIs without explicit project-owner approval.
+- ALWAYS use zero-retention configurations for any third-party service that touches sensitive data.
+- ALWAYS apply progressive disclosure for traumatic content.
+- ALWAYS isolate vendor dependencies behind project-owned interfaces.
+- Assume adversarial legal discovery, not just conventional attackers.
+- Prefer encrypted local storage and no third-party telemetry.
+
+---
+
+# Review Checklist
+
+Use this checklist on every AI-assisted change:
+
+1. DRY: search for existing logic before adding new functions or modules.
+2. Deep modules: reject thin wrappers and pass-through abstractions.
+3. Single responsibility: split mixed-abstraction functions.
+4. Error handling: never swallow failures or widen catch blocks carelessly.
+5. Information hiding: expose only what callers need.
+6. Ubiquitous language: use campaign, investigation, coalition, sanctuary, witness, and evidence correctly.
+7. Design for change: avoid hard-coding current vendors, schemas, or infrastructure assumptions.
+8. Legacy velocity: add characterization tests before changing AI-generated code you do not fully trust.
+9. Over-patterning: prefer plain functions over unnecessary Strategy/Factory/Observer scaffolding.
+10. Test quality: weak assertions and coverage theater do not count as verification.
+
+---
+
+# Testing
+
+Prefer spec-first tests over implementation-mirroring tests. Every test should encode a domain rule and fail when that rule is broken.
+
+- Verify tests fail for the right reason before fixing them.
+- Test error paths, not just success paths.
+- Use contract tests at service boundaries.
+- Prefer mutation score over raw coverage numbers.
+- Test adversarial inputs: SQL injection, XSS through testimony, path traversal through evidence uploads, oversized offline-sync payloads.
+- Keep test loops fast; AI-assisted workflows degrade badly with slow or flaky suites.
+
+For advocacy systems, also test:
+
+- anonymization is irreversible
+- coalition data does not cross organizational boundaries accidentally
+- traumatic content does not render without explicit opt-in
+- offline behavior fails safely when sync is interrupted
+
+---
+
+# Security
+
+Advocacy software faces three adversaries: state surveillance, industry infiltration, and unsafe AI/provider behavior.
+
+- Verify every dependency; slopsquatting is a real AI-era supply chain risk.
+- Require zero-retention handling for sensitive API flows.
+- Encrypt local evidence and activist data.
+- Strip metadata from investigation content aggressively.
+- Treat instruction files as security-sensitive artifacts; hidden backdoor text is a credible attack class.
+- Audit any MCP or external tool integration as an attack-surface expansion.
+- Design for device seizure: no plaintext temp files, no revealing crash dumps, no unsafe recovery flows.
+
+---
+
+# Privacy
+
+- Minimize stored data aggressively.
+- Separate authentication identity from operational identity.
+- Treat deletion as real deletion, not a soft-delete flag.
+- Re-consent when scope changes.
+- Apply the strictest coalition partner policy to any shared workflow.
+- Protect whistleblowers and witnesses with encryption, anonymization, and least-knowledge architectures.
+
+If a field appeared in court, ask who it would endanger before storing it.
+
+---
+
+# Cost Optimization
+
+- Route routine work to cheaper models and reserve frontier models for hard debugging, architecture, and security review.
+- Set hard session budgets; long drifting conversations waste money and reduce quality.
+- Optimize for cacheable, reusable project context.
+- Track cost per merged PR, not cost per generated line.
+- Evaluate self-hosted inference for sensitive or recurring workloads.
+
+Every dollar spent on AI compute is a dollar not spent on direct advocacy work.
+
+---
+
+# Advocacy Domain
+
+Use precise movement language. Do not invent synonyms.
+
+- Campaign: organized advocacy effort with defined goals.
+- Investigation: covert documentation operation; legally sensitive.
+- Coalition: multi-organization collaboration with explicit data boundaries.
+- Witness: person providing testimony; identity requires maximum protection.
+- Testimony: witness account subject to consent checks.
+- Sanctuary: permanent animal care facility.
+- Rescue: removal of animals from exploitative conditions.
+- Liberation: direct action to free animals; distinct legal implications.
+- Evidence: documentation with potential legal use.
+
+Keep bounded contexts separate: investigation operations, public campaigns, coalition coordination, and legal defense are different systems with different rules.
+
+---
+
+# Accessibility
+
+- Design for internationalization from the start.
+- Optimize for low-bandwidth and mobile-first environments.
+- Prefer offline-first behavior for critical workflows.
+- Use progressive disclosure and low-literacy-friendly interface patterns.
+- Fail safely under degraded conditions: no unsafe plaintext fallback when protective systems fail.
+
+---
+
+# Emotional Safety
+
+- Never show graphic content by default.
+- Require clear content warnings before traumatic material.
+- Provide configurable detail levels and remember user preference.
+- Never autoplay investigation footage or distressing audio.
+- Support review workflows that minimize repeated exposure to suffering.
+
+Emotional safety is an operational requirement, not cosmetic UX polish.
+
+---
+
+# On-Demand Workflows
+
+When a task calls for a specific process, follow the matching workflow:
+
+- git-workflow: atomic commits, short-lived branches, curated PRs
+- testing-strategy: spec-first tests, mutation-guided strengthening, anti-pattern detection
+- requirements-interview: gather purpose, threats, coalition boundaries, user safety, and budget constraints
+- plan-first-development: spec, decompose, implement incrementally, verify continuously
+- code-review: layered review focused on correctness, Ousterhout red flags, and advocacy-specific risks
+- security-audit: dependency verification, retention checks, seizure readiness, data-boundary verification

--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,25 @@
+# Codex Instruction Set
+
+Configuration files for OpenAI Codex. Codex uses `AGENTS.md` as its shared project instruction file across local and GitHub-connected workflows.
+
+## Structure
+
+```text
+AGENTS.md                  # Main project instruction file for Codex
+```
+
+## How It Works
+
+- `AGENTS.md` lives at the project root and provides the persistent project context Codex should follow.
+- The file is written for Codex's execution model: read first, patch carefully, verify changes, and surface approval boundaries clearly.
+- Commit `AGENTS.md` to the repository so local Codex sessions and GitHub-connected Codex tasks use the same instructions.
+
+## Setup
+
+Copy into your project root:
+
+```bash
+cp AGENTS.md your-project/
+```
+
+Then edit the domain language, safety constraints, and verification commands for your own stack.

--- a/opencode/AGENTS.md
+++ b/opencode/AGENTS.md
@@ -1,0 +1,180 @@
+# AGENTS.md — OpenCode Instructions
+
+This file is for OpenCode. Put it at the project root so OpenCode loads native project rules instead of relying on fallback compatibility with other tools.
+
+---
+
+# Project Identity
+
+This is an animal advocacy and liberation platform. The domain is high-risk: investigation data is subpoena-target evidence, activists may face criminal prosecution, and software failures can expose people, operations, and rescued animals to serious harm. Design and review this system as movement infrastructure, not generic startup software.
+
+Primary users include investigators, campaign organizers, coalition partners, legal defense teams, and sanctuary operators. Each role has different trust boundaries, data sensitivity, and operational risks.
+
+---
+
+# OpenCode Operating Notes
+
+- Prefer native `AGENTS.md` instructions over fallback `CLAUDE.md` compatibility.
+- Keep this file as the shared baseline; use `opencode.json` `instructions` only for supplemental documents when needed.
+- Read before editing and keep changes small enough to review easily.
+- Use plan-first exploration before broad edits on unfamiliar code.
+- Run tests or equivalent verification before finishing; if the repo has no tests, say so and verify structure another way.
+- Be explicit about approvals, destructive operations, network access, and GitHub side effects.
+
+---
+
+# Workflow
+
+Read before writing. Plan before code. Verify after changes.
+
+For any meaningful change:
+
+1. Read the existing code and identify the bounded context.
+2. Write a short specification with behavior, inputs, outputs, failures, and safety requirements.
+3. Decompose the work into small subtasks.
+4. Implement one subtask at a time.
+5. Verify each change with tests or a clearly stated substitute.
+
+Two-failure rule: after two failed fix attempts on the same issue, stop and rethink the approach.
+
+Comprehension rule: do not ship code you cannot explain in your own words.
+
+---
+
+# Hard Constraints
+
+- NEVER log, store, or transmit activist personally identifiable information.
+- NEVER send sensitive advocacy data to external APIs without explicit project-owner approval.
+- ALWAYS use zero-retention settings for third-party services that touch sensitive data.
+- ALWAYS use progressive disclosure for traumatic content.
+- ALWAYS isolate vendor dependencies behind project-owned interfaces.
+- Assume adversarial legal discovery in addition to hostile attackers.
+- Prefer encrypted local storage and no third-party telemetry.
+
+---
+
+# Review Checklist
+
+Review all AI-assisted changes against these failure modes:
+
+1. DRY violations and duplicated logic
+2. Shallow wrappers and pass-through abstractions
+3. Multi-responsibility functions
+4. Weak or hidden error handling
+5. Leaky interfaces and poor information hiding
+6. Domain-language drift
+7. Designs that are brittle under future change
+8. Untested edits to fast-aging AI-generated legacy code
+9. Unnecessary design patterns
+10. Weak tests that pass without proving behavior
+
+---
+
+# Testing
+
+Use spec-first tests wherever possible. A test should encode an actual rule and fail when that rule is broken.
+
+- Check that failures happen for the expected reason.
+- Test unhappy paths, edge cases, and adversarial inputs.
+- Prefer mutation-informed improvement over coverage theater.
+- Add characterization tests before changing unclear legacy behavior.
+- Keep the test loop fast; AI-assisted work degrades under slow or flaky verification.
+
+For advocacy systems, verify:
+
+- anonymization cannot be reversed
+- coalition data boundaries hold
+- sensitive content stays hidden until explicit opt-in
+- offline-first behavior degrades safely
+
+---
+
+# Security
+
+This system must defend against state surveillance, industry infiltration, and unsafe provider behavior.
+
+- Verify dependencies before installation; AI-era slopsquatting is a real risk.
+- Keep sensitive API usage zero-retention.
+- Encrypt evidence and activist data at rest.
+- Strip metadata from investigation content aggressively.
+- Treat instruction files as security-sensitive because hidden directives can backdoor AI behavior.
+- Audit external tools, MCP servers, and integrations as part of the threat model.
+- Design for device seizure and abrupt power loss without leaking plaintext state.
+
+---
+
+# Privacy
+
+- Store the minimum data required for each workflow.
+- Separate legal identity from operational identity.
+- Make deletion real, not cosmetic.
+- Reconfirm consent when usage scope changes.
+- Apply the strictest partner policy at coalition boundaries.
+- Protect witnesses and whistleblowers with encryption, anonymization, and least-knowledge handling.
+
+If disclosed in legal proceedings, every stored field becomes evidence. Design accordingly.
+
+---
+
+# Cost Optimization
+
+- Route simple work to cheaper models and reserve expensive models for hard problems.
+- Set session budgets and avoid drift-heavy conversations.
+- Keep static project context stable and reusable.
+- Measure cost per useful outcome, especially per merged PR.
+- Evaluate self-hosted inference when privacy or cost makes it rational.
+
+Advocacy budgets are finite. Efficiency is part of mission stewardship.
+
+---
+
+# Advocacy Domain
+
+Use precise domain language. Do not substitute generic synonyms.
+
+- Campaign: organized advocacy effort with milestones and goals
+- Investigation: covert documentation operation; legally sensitive
+- Coalition: alliance of organizations with explicit boundary rules
+- Witness: person providing testimony; identity requires maximum protection
+- Testimony: witness account gated by consent
+- Sanctuary: permanent animal care facility
+- Rescue: removal of animals from exploitative conditions
+- Liberation: direct action with distinct legal implications
+- Evidence: documentation with potential legal use
+
+Keep investigation operations, public campaigns, coalition coordination, and legal defense as distinct bounded contexts.
+
+---
+
+# Accessibility
+
+- Build for internationalization from day one.
+- Optimize for low-bandwidth and constrained devices.
+- Prefer offline-first critical flows.
+- Use low-literacy-friendly, progressively disclosed interfaces.
+- Under degradation, fail safely rather than exposing sensitive data or unsafe states.
+
+---
+
+# Emotional Safety
+
+- Never display graphic content by default.
+- Put content warnings before traumatic material.
+- Provide configurable detail levels that persist.
+- Never autoplay investigation footage or distressing audio.
+- Support safer review workflows that reduce repeated exposure.
+
+This is a duty-of-care requirement, not optional UX polish.
+
+---
+
+# On-Demand Workflows
+
+For recurring tasks, follow these workflows:
+
+- git-workflow: atomic commits, short-lived branches, focused PRs
+- testing-strategy: spec-first tests, mutation-guided strengthening, anti-pattern review
+- requirements-interview: clarify purpose, threats, coalition boundaries, user safety, and budget
+- plan-first-development: read, spec, decompose, implement incrementally, verify continuously
+- code-review: layered review for correctness, design quality, and advocacy-specific risks
+- security-audit: dependency, retention, encryption, seizure, and data-boundary review

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,25 @@
+# OpenCode Instruction Set
+
+Configuration files for OpenCode. OpenCode uses `AGENTS.md` as its native project instruction file and can supplement it with `opencode.json` instruction references when needed.
+
+## Structure
+
+```text
+AGENTS.md                  # Main project instruction file for OpenCode
+```
+
+## How It Works
+
+- `AGENTS.md` at the project root is the primary OpenCode rules file.
+- This package uses OpenCode's native rules format instead of relying on fallback `CLAUDE.md` compatibility.
+- If a project later needs additional modular docs, they can be layered in through `opencode.json` `instructions`, while keeping `AGENTS.md` as the shared team baseline.
+
+## Setup
+
+Copy into your project root:
+
+```bash
+cp AGENTS.md your-project/
+```
+
+Then edit the domain language, workflow constraints, and verification commands for your own stack.


### PR DESCRIPTION
This PR adds first-class support for Codex and OpenCode.

What changed:

- added `codex/AGENTS.md`
- added `codex/README.md`
- added `opencode/AGENTS.md`
- added `opencode/README.md`
- updated the top-level `README.md` to list both tools in quick start, file counts, and tool descriptions

Why:

- Codex is currently only supported indirectly through the generic `agents-md/AGENTS.md` fallback
- OpenCode also benefits from a native package instead of relying on compatibility assumptions
- this repo already provides first-class packages for many other tools, so adding dedicated support improves discoverability and consistency

Verification:

- `git diff --check`
- copied both `codex/AGENTS.md` and `opencode/AGENTS.md` into temp project roots to confirm the package shape works as documented
- verified README counts and references are internally consistent

This is intentionally separate from PR #4 so the Claude Code bugfix review stays focused 🐾
