### PR TITLE
fix: replace default CodeQL setup with Actions-only scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "17 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["actions"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- CodeQL default setup was auto-configured to scan `javascript-typescript`, but this repo contains only markdown and YAML configuration files -- no JS/TS source code
- Error: `CodeQL detected code written in GitHub Actions, but not any written in JavaScript/TypeScript`
- Disabled the broken default setup via API and added an explicit workflow that scans only the `actions` language (GitHub Actions YAML files)

## What changed
- Disabled CodeQL default setup (was misconfigured for `javascript-typescript`)
- Added `.github/workflows/codeql.yml` configured to scan only `actions` language
- Runs on push/PR to main and weekly schedule

## Test plan
- [ ] Verify the new CodeQL workflow passes on merge to main
- [ ] Confirm no more "configuration error" status on the repo's code scanning page