### PR TITLE
docs: fix README wording drift

### DIFF
--- a/aider/README.md
+++ b/aider/README.md
@@ -7,7 +7,7 @@ This directory contains a single file, `CONVENTIONS.md`, which provides project-
 `CONVENTIONS.md` is a comprehensive instruction file covering:
 
 - **7 concerns**: design principles, testing, security, privacy, cost optimization, accessibility, emotional safety
-- **6 process skills**: git workflow, testing strategy, requirements gathering, plan-first development, code review, security audit
+- **6 process skills**: git workflow, testing strategy, requirements interview, plan-first development, code review, security audit
 
 The file references Aider-specific features:
 

--- a/github-copilot/README.md
+++ b/github-copilot/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Instruction Set
 
-Configuration files for GitHub Copilot (VS Code, JetBrains, CLI). This is the richest instruction hierarchy of the four tools, with five distinct configuration elements.
+Configuration files for GitHub Copilot (VS Code, JetBrains, CLI). This is the richest instruction hierarchy in the repository, with five distinct configuration elements.
 
 ## Structure
 


### PR DESCRIPTION
## Summary
- fix the GitHub Copilot README to describe its instruction hierarchy relative to the current repository
- rename the Aider process skill from requirements gathering to requirements interview for consistency with the rest of the repo

## Verification
- git diff --check
- rg -n "four tools|requirements gathering" . --glob '!**/.git/**'

## Notes
- This repository does not include a formal test, lint, or build setup.