### PR TITLE
chore: prepare repo for public visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.env
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+*.log
+node_modules/
+__pycache__/


### PR DESCRIPTION
## Summary
- Add .gitignore

Part of org-wide public readiness preparation.