### PR TITLE
Add external contribution safety rules for all AI coding tools

### DIFF
--- a/agents-md/AGENTS.md
+++ b/agents-md/AGENTS.md
@@ -324,6 +324,45 @@ Before committing, branching, or creating a pull request. After an AI agent has 
 
 ---
 
+# External Contribution Safety
+
+When contributing to a repository your organization does not own, suppress all tool identity, org attribution, and advocacy framing from every artifact you produce.
+
+## Repo Classification
+
+Check `git remote get-url origin` before writing any commit message, PR description, or branch name.
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal repo** — full identity is fine.
+- Remote is anything else → **external repo** — apply all rules below.
+- No remote configured → treat as **external** (safe default).
+
+There is no ambiguity. Positive confirmation of an internal remote is required to use internal identity. Absent that confirmation, stay in external mode.
+
+## What to Suppress
+
+- **Tool identity** — No mention of the AI coding tool (Claude Code, Copilot, Cursor, Cline, Windsurf, or any other) in commits, PRs, branch names, or code comments.
+- **Organization** — No mention of Open Paws or any advocacy organization in any contribution artifact.
+- **Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+- **Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution in commit messages or PR descriptions.
+
+## Commit Messages
+
+Read the last five commits first: `git log --oneline -5`. Match their exact style. Proportional to the diff: one-line change, one-line commit. Imperative mood ("Fix", "Add", "Update"). No AI-generated patterns ("This commit introduces...", "Updated X to support Y"). Self-check: does this look indistinguishable from the existing commits in this repo?
+
+## PR Descriptions
+
+Check merged PRs first: `gh pr list --state merged --limit 5`. Match their style. No section headers for small changes. No bullet lists of benefits. One to three sentences. Self-check: does this sound like a developer who works on this codebase, without an agenda? If not, cut it by half.
+
+## Branch Names
+
+Use the target repo's convention. Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth
+
+These instructions are last-line-of-defense. Configure your tool to disable attribution trailers before making external contributions — tool configuration is the first line. Instructions to the AI are what you rely on when configuration fails or when the tool generates prose (PR descriptions, branch names) that configuration does not control.
+
+---
+
 # Skill: Testing Strategy
 
 ## When to Use

--- a/aider/CONVENTIONS.md
+++ b/aider/CONVENTIONS.md
@@ -200,6 +200,8 @@ Use Aider's automatic commit feature — every change is committed with a sensib
 
 **Merge strategy.** Squash-merge ephemeral branches. Delete immediately after merge.
 
+**External contribution safety.** When contributing to a third-party repository (any repo whose remote does not match `github.com/Open-Paws/`), suppress all tool identity, org attribution, and advocacy framing from commits, PR descriptions, and branch names. Check the remote with `git remote get-url origin` before writing any commit message or PR description. Read the last five commits (`git log --oneline -5`) and match the target repo's exact style: length, format, tense. Imperative mood only. No AI-generated patterns ("This commit introduces...", "Updated X to support Y"). No `Co-Authored-By:` trailers, no "Generated with" footers. No mentions of Open Paws, Aider, or any AI tool. Check merged PRs (`gh pr list --state merged --limit 5`) and match their description style: one to three sentences, no benefit bullet lists, no section headers for small changes. Branch names: `fix/short-description` or `add/short-description`, under 40 characters, no advocacy language. If there is no remote, default to external mode. There is no ambiguity: positive confirmation of an internal remote is required to unlock internal identity; absent that, stay in external mode.
+
 ---
 
 ## Testing Strategy

--- a/augment-code/.augment/rules/external-contribution-safety.md
+++ b/augment-code/.augment/rules/external-contribution-safety.md
@@ -1,0 +1,63 @@
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of Augment Code, Claude, Copilot, Cursor, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y".
+- Self-check: indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No headers for changes under 100 lines.
+- No bullet lists of benefits.
+- One to three sentences explaining what changed and why.
+- Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming in External Repos
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. Disable attribution trailers in Augment Code settings before making external contributions.

--- a/claude-code/.claude/rules/external-contribution-safety.md
+++ b/claude-code/.claude/rules/external-contribution-safety.md
@@ -1,0 +1,78 @@
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — the AI tool must suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches. This is last-line-of-defense enforcement: configure your tool to disable attribution trailers as the first line, and rely on these instructions when configuration alone is insufficient.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- If the remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` (SSH), you are in an **internal repo** — full identity is fine.
+- If the remote is anything else, treat it as **external** — apply all rules below.
+- If there is no remote configured, treat it as **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absence of a matching remote is not ambiguous — it defaults to external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — Do not mention Claude Code, Graze, Cursor, Copilot, Windsurf, Cline, or any other AI coding tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — Do not mention Open Paws, any Open Paws project name, or any advocacy organization in any contribution artifact.
+
+**Mission framing** — Do not use advocacy language (liberation, compassionate, animal rights, plant-based, vegan) in code, commits, PR titles, or PR bodies unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By: Claude` lines. No "Generated with Claude Code" footers. No AI attribution in commit messages or PR descriptions.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits in the target repo before writing a commit message:
+
+```bash
+git log --oneline -5
+```
+
+Match their exact style: length, format (conventional vs prose vs terse), tense, specificity. Then apply these constraints:
+
+- **Proportional to diff** — a one-line change gets a one-line commit. A 50-line change gets two or three sentences maximum.
+- **Imperative mood** — "Fix", "Add", "Update", not "Fixed", "Added", "Updated".
+- **No AI-generated patterns** — reject "This commit introduces...", "Updated X to support Y", "Added support for Z", "Improve overall...".
+- **Self-check** — Read the message. Does it look indistinguishable from the existing commits in this repo? If not, shorten it and remove any summary language.
+
+## PR Description Rules in External Repos
+
+Check how merged PRs are described in the target repo before writing a PR body:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+Then apply:
+
+- **Match the target repo's style** — if merged PRs are two sentences, write two sentences. If they use headers, use headers. If they use none, use none.
+- **No section headers for small changes** — omit `##`, `###`, "Summary:", "Motivation:", "Background:", "Approach:" unless the target repo uses them.
+- **No bullet lists of benefits** — a list of what this improves is an AI tell. One explanation of what changed and why is sufficient.
+- **Length** — most good external PRs are one to three sentences. Longer is rarely better.
+- **Self-check** — read it aloud. Does it sound like a developer who works on this codebase, without a toolkit or an agenda? If not, cut it by half.
+
+## Branch Naming in External Repos
+
+Check existing open PRs for branch naming conventions:
+
+```bash
+gh pr list --state open --limit 10
+```
+
+Use that convention. If no clear pattern exists, default to `fix/short-description` or `add/short-description`. Keep the branch name under 40 characters. Do not include advocacy language, org identifiers, or tool names in branch names.
+
+## Defense-in-Depth Principle
+
+These instructions are the last line of defense, not the first. Before contributing to any external repo, configure your tool to disable attribution trailers:
+
+- Claude Code: set `includeCoAuthoredBy: false` in `~/.claude/settings.json`
+- Cursor: disable "Add AI attribution" in settings
+- Copilot: no attribution trailers are inserted by default in commit flows
+
+Instructions to the AI are what you rely on when tool configuration fails or when the tool generates surrounding prose (PR descriptions, branch names) that configuration does not control.

--- a/cline/.clinerules/external-contribution-safety.md
+++ b/cline/.clinerules/external-contribution-safety.md
@@ -1,0 +1,63 @@
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of Cline, Claude, Copilot, Cursor, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y".
+- Self-check: indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No headers for changes under 100 lines.
+- No bullet lists of benefits.
+- One to three sentences explaining what changed and why.
+- Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming in External Repos
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. Disable attribution trailers in Cline settings before making external contributions.

--- a/cursor/.cursor/rules/external-contribution-safety.mdc
+++ b/cursor/.cursor/rules/external-contribution-safety.mdc
@@ -1,0 +1,66 @@
+---
+description: "Apply when committing, creating a branch, or writing a pull request in any repository whose git remote does not belong to your organization"
+---
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal repo**, full identity is fine.
+- Remote is anything else → **external repo**, apply all rules below.
+- No remote configured → treat as **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absence of a matching remote defaults to external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — Do not mention Claude Code, Graze, Cursor, Copilot, Windsurf, Cline, or any AI coding tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — Do not mention Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — Do not use advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution in commit messages or PR descriptions.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit. 50-line change gets two or three sentences maximum.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y", "Improve overall...".
+- Self-check: Does this look indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs in the target repo before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No section headers for changes under 100 lines.
+- No bullet lists of benefits.
+- Length: one to three sentences explaining what changed and why.
+- Self-check: Does this sound like a developer who works on this codebase, without an agenda? If not, cut it by half.
+
+## Branch Naming in External Repos
+
+Check existing open PRs for conventions. Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. Configure Cursor to disable attribution trailers before making external contributions. Instructions to the AI are what you rely on when configuration fails or when the tool generates prose (PR descriptions, branch names) that configuration does not control.

--- a/gemini-cli/GEMINI.md
+++ b/gemini-cli/GEMINI.md
@@ -263,6 +263,8 @@ Before committing, branching, or creating a PR. After an AI agent has generated 
 
 **Merge strategy.** Squash-merge ephemeral branches. Delete branches immediately after merge.
 
+**External contribution safety.** When contributing to a third-party repository (any repo whose remote does not match `github.com/Open-Paws/`), suppress all tool identity, org attribution, and advocacy framing from commits, PR descriptions, and branch names. Check the remote with `git remote get-url origin` before writing any commit message or PR description. Read the last five commits (`git log --oneline -5`) and match the target repo's exact style: length, format, tense. Imperative mood only. No AI-generated patterns ("This commit introduces...", "Updated X to support Y"). No `Co-Authored-By:` trailers, no "Generated with" footers. No mentions of Open Paws, Gemini CLI, or any AI tool. Check merged PRs (`gh pr list --state merged --limit 5`) and match their description style: one to three sentences, no benefit bullet lists, no section headers for small changes. Branch names: `fix/short-description` or `add/short-description`, under 40 characters, no advocacy language. If there is no remote, default to external mode. There is no ambiguity: positive confirmation of an internal remote is required to unlock internal identity; absent that, stay in external mode. When using Gemini CLI's sandbox mode for external contributions, verify the sandbox does not generate co-author trailers or tool attribution in commit output.
+
 ---
 
 ## Testing Strategy

--- a/github-copilot/.github/instructions/external-contribution-safety.md
+++ b/github-copilot/.github/instructions/external-contribution-safety.md
@@ -1,0 +1,66 @@
+---
+applyTo: "**"
+---
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of GitHub Copilot, Claude, Cursor, Windsurf, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y".
+- Self-check: indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No headers for changes under 100 lines.
+- No bullet lists of benefits.
+- One to three sentences explaining what changed and why.
+- Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming in External Repos
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. GitHub Copilot does not inject attribution trailers by default in commit flows, but verify this in your IDE settings before making external contributions.

--- a/jetbrains-junie/.junie/guidelines.md
+++ b/jetbrains-junie/.junie/guidelines.md
@@ -239,6 +239,8 @@ Before committing, branching, or creating a pull request.
 
 **Merge strategy.** Squash-merge ephemeral branches. Delete immediately after merge.
 
+**External contribution safety.** When contributing to a third-party repository (any repo whose remote does not match `github.com/Open-Paws/`), suppress all tool identity, org attribution, and advocacy framing from commits, PR descriptions, and branch names. Check the remote with `git remote get-url origin` before writing any commit message or PR description. Read the last five commits (`git log --oneline -5`) and match the target repo's exact style: length, format, tense. Imperative mood only. No AI-generated patterns ("This commit introduces...", "Updated X to support Y"). No `Co-Authored-By:` trailers. No mentions of Open Paws, Junie, or any AI tool. Check merged PRs (`gh pr list --state merged --limit 5`) and match their description style: one to three sentences, no benefit bullet lists, no section headers for small changes. Branch names: `fix/short-description` or `add/short-description`, under 40 characters, no advocacy language. If there is no remote, default to external mode. There is no ambiguity: positive confirmation of an internal remote is required to unlock internal identity; absent that, stay in external mode.
+
 ---
 
 ## Testing Strategy

--- a/kilo-code/.kilocode/rules/external-contribution-safety.md
+++ b/kilo-code/.kilocode/rules/external-contribution-safety.md
@@ -1,0 +1,63 @@
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of Kilo Code, Claude, Copilot, Cursor, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y".
+- Self-check: indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No headers for changes under 100 lines.
+- No bullet lists of benefits.
+- One to three sentences explaining what changed and why.
+- Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming in External Repos
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. Disable attribution trailers in Kilo Code settings before making external contributions.

--- a/roo-code/.roo/rules/external-contribution-safety.md
+++ b/roo-code/.roo/rules/external-contribution-safety.md
@@ -1,0 +1,63 @@
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of Roo Code, Claude, Copilot, Cursor, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules in External Repos
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+- Match their exact style: length, format, tense, specificity.
+- Proportional to diff: one-line change gets one-line commit.
+- Imperative mood: "Fix", "Add", "Update" — not "Fixed", "Added", "Updated".
+- No AI-generated patterns: "This commit introduces...", "Updated X to support Y".
+- Self-check: indistinguishable from the existing commits in this repo?
+
+## PR Description Rules in External Repos
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+- Match the target repo's description style.
+- No headers for changes under 100 lines.
+- No bullet lists of benefits.
+- One to three sentences explaining what changed and why.
+- Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming in External Repos
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth Principle
+
+These instructions are last-line-of-defense. Disable attribution trailers in Roo Code settings before making external contributions.

--- a/windsurf/.windsurf/rules/external-contribution-safety.md
+++ b/windsurf/.windsurf/rules/external-contribution-safety.md
@@ -1,0 +1,56 @@
+<!-- trigger: model_decision -->
+# External Contribution Safety
+
+When helping a developer contribute to a third-party repository — any repo whose git remote does not belong to your organization — suppress all identity, attribution, and advocacy framing from commits, pull requests, and branches.
+
+## Repo Classification
+
+Before producing any commit message, PR description, or branch name, check the remote:
+
+```bash
+git remote get-url origin
+```
+
+- Remote matches `github.com/Open-Paws/` or `github.com:Open-Paws/` → **internal**, full identity fine.
+- Remote is anything else → **external**, apply all rules below.
+- No remote configured → **external** (safe default).
+
+Confidence must be positive that you are in an internal repo. Absent positive confirmation, stay in external mode.
+
+## What to Suppress in External Repos
+
+**Tool identity** — No mentions of Windsurf, Cascade, Claude, Copilot, or any AI tool in commits, PR descriptions, branch names, or code comments.
+
+**Organization** — No mentions of Open Paws or any advocacy organization in any contribution artifact.
+
+**Mission framing** — No advocacy language (liberation, compassionate, animal rights, vegan) in code, commits, or PRs unless the target project is explicitly about those topics.
+
+**Attribution trailers** — No `Co-Authored-By:` lines. No "Generated with" footers. No AI attribution anywhere.
+
+## Commit Message Rules
+
+Read the last five commits before writing:
+
+```bash
+git log --oneline -5
+```
+
+Match their style. Proportional to diff. Imperative mood. No AI-generated patterns ("This commit introduces...", "Updated X to support Y"). Self-check: indistinguishable from existing commits?
+
+## PR Description Rules
+
+Check merged PRs before writing:
+
+```bash
+gh pr list --state merged --limit 5
+```
+
+Match the target repo's style. No headers for small changes. No bullet lists of benefits. One to three sentences. Self-check: sounds like a developer who works on this codebase, without an agenda?
+
+## Branch Naming
+
+Default: `fix/short-description` or `add/short-description`. Under 40 characters. No advocacy language, org identifiers, or tool names.
+
+## Defense-in-Depth
+
+These instructions are last-line-of-defense. Disable attribution trailers in Windsurf settings before making external contributions.


### PR DESCRIPTION
## Summary

- Adds `external-contribution-safety.md` rule file to 8 tool directories with dedicated rule systems (claude-code, cursor, windsurf, cline, roo-code, augment-code, kilo-code, github-copilot), covering identity suppression, commit hygiene, PR description hygiene, and branch naming when contributing to third-party repos
- Adds a new `# External Contribution Safety` section to `agents-md/AGENTS.md` (vendor-neutral)
- Adds the same rules inline to the monolithic instruction files for aider (`CONVENTIONS.md`), gemini-cli (`GEMINI.md`), and jetbrains-junie (`guidelines.md`)

## Why

Developers using these AI coding tools to contribute to external open-source repos risk:
- Attribution trailers (`Co-Authored-By: Claude`) linking the AI tool to external commits permanently
- Advocacy language leaking into third-party codebases
- AI-generated PR description patterns getting PRs flagged or rejected
- Unauthorized linking of Open Paws to external projects in commit history

The safe default must be documented: treat any repo whose remote does not match the org's allowlist as external, and apply full suppression. Confidence must be positive that you are in an internal repo; absent positive confirmation, stay in external mode.

## Test plan

- [ ] Rule file exists at `claude-code/.claude/rules/external-contribution-safety.md`
- [ ] Cursor MDC file exists at `cursor/.cursor/rules/external-contribution-safety.mdc` with correct `description` frontmatter
- [ ] Rule files exist for windsurf, cline, roo-code, augment-code, kilo-code, github-copilot
- [ ] `agents-md/AGENTS.md` has the new `# External Contribution Safety` section
- [ ] `aider/CONVENTIONS.md`, `gemini-cli/GEMINI.md`, and `jetbrains-junie/.junie/guidelines.md` each have the new paragraph under their Git Workflow section
- [ ] No existing rules contradict the new ones
- [ ] No advocacy language or attribution identifiers in the new rule content itself