### PR TITLE
docs: comprehensive README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,183 @@
+# AGENTS.md — structured-coding-with-ai
+
+This repo contains ready-to-use AI coding instruction files for 12 tools, tailored for animal advocacy software development. It is the canonical source for AI coding methodology across all Open Paws projects. If you are an AI agent reading this file, you are operating inside a library of instruction files that other AI agents will copy and use — content changes here propagate across the entire Open Paws developer ecosystem.
+
+**Status: 🟢 Production** — all 12 tool directories stable, CI running on every PR.
+
+---
+
+## What This Means for You
+
+This repo is unusual: it is instruction files whose consumers are other AI agents. A change to `claude-code/.claude/rules/security.md` affects every Claude Code session across all Open Paws projects that have copied those files. A change to `agents-md/AGENTS.md` affects 20+ AI tools. Treat content edits with the same care you would treat changes to a shared library used in production.
+
+Two downstream consumers depend on this repo's content directly:
+- **graze-cli** — bundles selected instruction files into its binary; content changes require verifying the bundled output still renders correctly
+- **desloppify** — generates agent skill files from the same content; structural changes to skill files may break the generation pipeline
+
+---
+
+## Directory Structure
+
+```
+structured-coding-with-ai/
+├── README.md                          Human-facing overview, copy commands, tool comparison table
+├── CLAUDE.md                          Repo-level context for Claude Code (ecosystem role, downstream consumers)
+├── AGENTS.md                          This file — context for AI agents working in this repo
+├── LICENSE                            MIT
+├── scripts/
+│   ├── check-unicode-integrity.py     Detects hidden Unicode characters in instruction files (Rules File Backdoor defense)
+│   └── tests/                         Tests for the integrity checker
+├── .github/                           CI workflows (Unicode integrity check runs on all PRs)
+├── .desloppify/                       Desloppify configuration for this repo
+├── .pre-commit-config.yaml            Pre-commit hooks (includes speciesist language check)
+│
+├── claude-code/                       Claude Code — 17 files
+│   ├── CLAUDE.md                      Root instruction file (under 60 lines, links to rules/)
+│   ├── hooks-template.md              Pre-commit / post-edit / pre-push hook configuration guide
+│   └── .claude/
+│       ├── rules/                     8 scoped rule files (always-loaded and path-targeted)
+│       │   ├── testing.md
+│       │   ├── security.md
+│       │   ├── privacy.md
+│       │   ├── cost-optimization.md
+│       │   ├── advocacy-domain.md
+│       │   ├── accessibility.md
+│       │   ├── emotional-safety.md
+│       │   ├── external-contribution-safety.md
+│       │   ├── desloppify.md
+│       │   └── geo-seo.md
+│       └── skills/                    7 process skill directories (invoked on demand)
+│           ├── advocacy-code-review/
+│           ├── advocacy-testing-strategy/
+│           ├── geo-seo-audit/
+│           ├── git-workflow/
+│           ├── plan-first-development/
+│           ├── requirements-interview/
+│           └── security-audit/
+│
+├── cursor/                            Cursor — 14 files (.cursorrules + .cursor/rules/*.mdc)
+├── github-copilot/                    GitHub Copilot — 23 files (richest hierarchy of any tool)
+├── windsurf/                          Windsurf — 14 files (6K/12K char limits enforced)
+├── kilo-code/                         Kilo Code — 21 files (Memory Bank pattern)
+├── cline/                             Cline — 14 files (Plan/Act paradigm)
+├── roo-code/                          Roo Code — 19 files (.roomodes JSON + mode rules)
+├── augment-code/                      Augment Code — 14 files
+├── aider/                             Aider — 1 file (CONVENTIONS.md)
+├── gemini-cli/                        Gemini CLI — 1 file (GEMINI.md)
+├── jetbrains-junie/                   JetBrains / Junie — 1 file (.junie/guidelines.md)
+└── agents-md/                         AGENTS.md standard — 1 file (vendor-neutral, 20+ tools)
+```
+
+---
+
+## How to Use These Files
+
+### If you are adding a new feature to an instruction file
+
+1. Read the existing file in full before editing. Each tool was independently authored — do not assume the structure matches other tools.
+2. Identify which tools need the same change. A content update typically needs to propagate across all 12 tool directories. Check whether the change is concept-level (needs propagating everywhere) or format-level (specific to one tool's mechanism).
+3. Run `python scripts/check-unicode-integrity.py` after any edit. This is also enforced by CI.
+4. Run `semgrep --config semgrep-no-animal-violence.yaml` on all edited `.md` files before committing.
+5. Keep instruction files lean. Every token in these files is loaded into every AI session that uses them. Across the bootcamp cohort, token cost compounds — do not add content without justification.
+
+### If you are adding a new tool directory
+
+1. Create `tool-name/` at repo root.
+2. Implement all 7 concerns: testing, security, privacy, cost-optimization, advocacy-domain, accessibility, emotional-safety.
+3. Implement all 6 process skills: git-workflow, testing-strategy, requirements-interview, plan-first-development, code-review, security-audit.
+4. Add external-contribution-safety content (two-state identity model: advocacy mode vs. neutral mode).
+5. Add a `README.md` inside the directory with the copy command and file list.
+6. Add a row to the table in `README.md` at the repo root.
+7. Update `CLAUDE.md` architecture section if the new directory changes the overall structure.
+8. Do not copy content verbatim from another tool directory and relabel it. Each tool must be independently authored for its native format and activation mechanisms.
+
+### If you are reviewing a PR
+
+The most common failure modes in this repo are:
+- Introducing synonyms for established domain terms (see advocacy-domain language dictionary in `CLAUDE.md`)
+- Adding graphic investigation content to example prompts or test scenarios (violates emotional-safety concern)
+- Copying content across tool directories rather than independently authoring for each format
+- Edits that break the structural assumptions of downstream consumers (graze-cli bundling, desloppify skill generation)
+- Hidden Unicode characters introduced through copy-paste from external sources
+
+---
+
+## Most Important Files by Task
+
+| Task | Key files |
+|------|-----------|
+| Understand the repo's role in the ecosystem | `CLAUDE.md` |
+| Copy instructions for a specific tool | `README.md` (copy commands section) |
+| Claude Code implementation reference | `claude-code/CLAUDE.md`, `claude-code/.claude/rules/`, `claude-code/.claude/skills/` |
+| Universal / tool-agnostic reference | `agents-md/AGENTS.md` |
+| Security rule for advocacy context | `claude-code/.claude/rules/security.md` |
+| Domain language enforcement | `claude-code/.claude/rules/advocacy-domain.md` |
+| External contribution workflow | `claude-code/.claude/rules/external-contribution-safety.md` |
+| Git workflow (issue-first, worktrees, desloppify gate) | `claude-code/.claude/skills/git-workflow/` |
+| Instruction file integrity defense | `scripts/check-unicode-integrity.py` |
+| Hook configuration | `claude-code/hooks-template.md` |
+
+---
+
+## Content Architecture
+
+All 12 tool sets cover the same conceptual content, implemented in each tool's native format:
+
+**7 Concerns** (always active — loaded into every AI session using these files):
+1. Testing
+2. Security
+3. Privacy
+4. Cost optimization
+5. Advocacy domain
+6. Accessibility
+7. Emotional safety
+
+**6 Process Skills** (invoked on demand — triggered by user request or task type):
+1. git-workflow
+2. testing-strategy
+3. requirements-interview
+4. plan-first-development
+5. code-review
+6. security-audit
+
+**1 Cross-cutting rule** (always active):
+- external-contribution-safety (two-state identity model)
+
+Tools with multi-file support (Claude Code, Cursor, GitHub Copilot, Windsurf, Kilo Code, Cline, Roo Code, Augment Code) implement concerns and skills as separate files with appropriate activation triggers. Single-file tools (Aider, Gemini CLI, JetBrains/Junie, AGENTS.md) condense all content into clearly-headed sections.
+
+---
+
+## Security Notes for This Repo
+
+**Instruction file integrity** — Hidden Unicode characters in instruction files are the Rules File Backdoor attack vector. An attacker who can inject such characters into these files can invisibly alter the behavior of every AI agent that copies and uses them. The CI Unicode integrity check (`scripts/check-unicode-integrity.py`) is a first-class security control, not optional linting.
+
+**Content provenance** — Do not copy instruction file content from external sources without review. This includes AI-generated content that you have not audited character by character. Always run the integrity check after any content that passed through an external system.
+
+**No activist data in examples** — Example prompts, sample scenarios, and test fixtures must not contain real investigation details, activist identities, coalition information, or operational details. Abstract test data only.
+
+---
+
+## Quality Gates
+
+Before opening a PR:
+
+```bash
+# Instruction file integrity
+python scripts/check-unicode-integrity.py
+
+# Speciesist language
+semgrep --config semgrep-no-animal-violence.yaml .
+
+# Desloppify (target score ≥ 85)
+pip install "git+https://github.com/Open-Paws/desloppify.git#egg=desloppify[full]"
+desloppify scan --path .
+```
+
+---
+
+## Known Issues and TODOs
+
+- The file count in `README.md` shows 140 — the actual count across all tool directories should be verified as new files are added. The canonical count is whatever `find . -name "*.md" -o -name "*.mdc" -o -name "*.json" | grep -v ".github\|scripts\|README\|CLAUDE\|AGENTS\|LICENSE" | wc -l` returns at HEAD.
+- Windsurf's persistent memory feature requires manual review for sensitive projects. Consider adding a warning in the Windsurf `README.md` specific to investigation operations.
+- The `geo-seo.md` rule file in `claude-code/.claude/rules/` is significantly larger than other rule files (36K vs ~5K). This may warrant splitting or summarizing for token-efficiency at bootcamp scale.
+- Tools-Platform#1 repo verification is still pending (as of 2026-04-09 clean-room agent architecture rollout). Do not mark that rollout complete until that PR is verified.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # Structured Coding Library for Animal Advocacy
 
+> **Status: 🟢 Production** — actively maintained, all 12 tool directories stable, CI running on every PR.
+> Part of the [Open Paws](https://github.com/Open-Paws) developer ecosystem.
+
 Ready-to-use instruction file sets for 12 AI coding tools, designed for anyone building software for animal advocacy and liberation. Each tool directory is self-contained: copy it into your project root and your AI assistant immediately understands advocacy-domain constraints, security threat models, testing standards, and process workflows. No external dependencies, no shared config, no setup beyond copying files.
+
+---
+
+## Why This Exists
+
+Generic AI coding setups treat every codebase the same. Advocacy software is not generic. It operates under a three-adversary threat model (state surveillance, industry infiltration, AI model bias), handles data that is potential evidence under ag-gag statutes, and serves users who face genuine legal risk. The instruction files in this repo encode all of that — so every AI session starts with the right constraints rather than having to re-explain them.
+
+This repo is the **canonical source for AI coding methodology** across all Open Paws projects. It feeds two downstream consumers:
+- **[graze-cli](https://github.com/Open-Paws/graze-cli)** — bundles selected instruction files into its binary for advocacy-aware agentic coding
+- **[desloppify](https://github.com/Open-Paws/desloppify)** — generates agent skill files from the same content
+
+It also serves as curriculum for the Open Paws developer training bootcamp, where developers learn the 7 concerns and 6 process skills through hands-on project work.
 
 ---
 
@@ -50,6 +65,8 @@ cp -r jetbrains-junie/.junie your-project/
 cp agents-md/AGENTS.md your-project/
 ```
 
+After copying, add your project's own build commands, linting configuration, language conventions, and tech stack details. These files provide principles and methodology — they do not replace project-specific setup.
+
 ---
 
 ## What's Included
@@ -76,70 +93,144 @@ cp agents-md/AGENTS.md your-project/
 
 Every tool covers the same material, adapted to its native format. Tools with multi-file support break content into separate files with appropriate activation triggers. Single-file tools condense everything into clearly-headed sections.
 
-**7 concerns** (present in every tool):
+### 7 Concerns (present in every tool)
 
-- **Testing** -- Assertion quality, spec-first generation, property-based testing, mutation testing, adversarial input testing
-- **Security** -- Zero-retention APIs, ag-gag legal exposure, supply chain verification, device seizure preparation, three-adversary threat model
-- **Privacy** -- Activist identity protection, coalition data sharing, whistleblower protection, GDPR/CCPA compliance, data minimization
-- **Cost optimization** -- Model routing, token budgets, prompt caching, vendor lock-in as movement risk, nonprofit budget allocation
-- **Advocacy domain** -- Ubiquitous language dictionary, bounded contexts (investigation ops / public campaigns / coalition coordination / legal defense), entity definitions
-- **Accessibility** -- i18n, offline-first, low-bandwidth, low-literacy design, mesh networking, device seizure resilience
-- **Emotional safety** -- Progressive disclosure of traumatic content, configurable detail levels, content warnings, secondary trauma mitigation
+- **Testing** — Assertion quality, spec-first generation, property-based testing, mutation testing, adversarial input testing
+- **Security** — Zero-retention APIs, ag-gag legal exposure, supply chain verification, device seizure preparation, three-adversary threat model
+- **Privacy** — Activist identity protection, coalition data sharing, whistleblower protection, GDPR/CCPA compliance, data minimization
+- **Cost optimization** — Model routing, token budgets, prompt caching, vendor lock-in as movement risk, nonprofit budget allocation
+- **Advocacy domain** — Ubiquitous language dictionary, bounded contexts (investigation ops / public campaigns / coalition coordination / legal defense), entity definitions
+- **Accessibility** — i18n, offline-first, low-bandwidth, low-literacy design, mesh networking, device seizure resilience
+- **Emotional safety** — Progressive disclosure of traumatic content, configurable detail levels, content warnings, secondary trauma mitigation
 
-**7 process skills** (workflow guides invoked on demand):
+### 6 Process Skills (workflow guides invoked on demand)
 
-- **git-workflow** -- Issue-first GitHub workflow: worktree-per-task, plan→review→implement loops, desloppify gate, PR monitoring until merged
-- **testing-strategy** -- Spec-first generation, five anti-patterns to avoid (snapshot trap, mock everything, happy path only, test-after-commit, coverage theater), mutation-guided improvement
-- **requirements-interview** -- Structured stakeholder questions covering threat model, coalition needs, user safety, budget constraints
-- **plan-first-development** -- Spec, design, decompose, implement one subtask at a time, generation-then-comprehension pattern
-- **code-review** -- Layered review pipeline, Ousterhout red flags, AI-specific failure patterns, advocacy-specific data leak checks
-- **security-audit** -- Advocacy threat model assessment, slopsquatting defense, prompt injection / rules file backdoor detection, MCP server security
-- **geo-seo-audit** -- GEO/SEO verification workflow (Core Web Vitals, structured data, indexing controls, AI citation-risk checks)
+- **git-workflow** — Issue-first GitHub workflow: worktree-per-task, plan-then-review-then-implement loops, desloppify gate, PR monitoring until merged
+- **testing-strategy** — Spec-first generation, five anti-patterns to avoid (snapshot trap, mock everything, happy path only, test-after-commit, coverage theater), mutation-guided improvement
+- **requirements-interview** — Structured stakeholder questions covering threat model, coalition needs, user safety, budget constraints
+- **plan-first-development** — Spec, design, decompose, implement one subtask at a time, generation-then-comprehension pattern
+- **code-review** — Layered review pipeline, Ousterhout red flags, AI-specific failure patterns, advocacy-specific data leak checks
+- **security-audit** — Advocacy threat model assessment, slopsquatting defense, prompt injection / rules file backdoor detection, MCP server security
+
+### External Contribution Safety
+
+All 12 tool directories include external contribution safety content. This teaches the two-state identity model: **advocacy mode** for Open Paws repos (full domain context, movement terminology, seven concerns active), and **neutral mode** for external open-source repos (org identity suppressed, commit hygiene enforced, no advocacy-specific framing in commits or PRs). This prevents AI agents from inadvertently identifying contributors or leaking organizational context when contributing to third-party projects.
+
+---
+
+## Tool-by-Tool Reference
+
+**Claude Code** — `CLAUDE.md` at project root (under 60 lines), scoped rules in `.claude/rules/` with optional `paths:` frontmatter for file-targeted activation, process skills in `.claude/skills/` with YAML frontmatter (prefixed `advocacy-` to avoid shadowing global skills). Supports hooks for deterministic enforcement of formatting, linting, and security scanning. See `hooks-template.md` for hook configuration.
+
+**Cursor** — `.cursorrules` at project root (always loaded), scoped rules in `.cursor/rules/*.mdc` using MDC format with four activation modes: Always Apply, Auto Attached (glob-triggered), Agent Requested (description-triggered), and Manual (user invokes with @).
+
+**GitHub Copilot** — The richest instruction hierarchy of any tool covered. `.github/copilot-instructions.md` (repo-wide), `.github/instructions/` (path-specific with `applyTo:`), `.github/prompts/` (reusable user-invocable workflows), `.github/chat-modes/` (persistent agent personas for advocacy review and requirements interviewing), `.github/skills/` (process skill packages).
+
+**Windsurf** — `.windsurf/rules/*.md` with four trigger types: Always On, Model Decision, Glob, and Manual. Hard constraint of 6,000 characters per file and 12,000 characters combined. Always On files budgeted to ~8K total to leave headroom for contextually loaded files. Note: Windsurf generates persistent memories about your codebase — review and clear these regularly for sensitive projects.
+
+**Kilo Code** — `.kilocode/rules/` with five mode-specific rule files (Ask, Architect, Code, Debug, Orchestrator), a Memory Bank (`brief.md`, `context.md`, `history.md`) for progressive context disclosure, seven concern files, and seven process skills in `.kilocode/skills/`.
+
+**Cline** — `.clinerules/` directory with 14 Markdown files. Emphasizes Cline's Plan/Act paradigm: explore in Plan Mode before changing anything in Act Mode. All concern and skill content as separate rule files.
+
+**Roo Code** — `.roomodes` JSON defining custom modes (Review and Interview) with tool restrictions and model assignments, plus `.roo/rules/` containing five mode-specific rule files (Architect, Code, Debug, Review, Interview), seven concern files, and seven skill files. Supports Boomerang Task delegation between modes.
+
+**Augment Code** — `.augment/rules/*.md` with a `main.md` core file plus 13 concern and skill files. All files loaded as directory-based rules.
+
+**Aider** — Single `CONVENTIONS.md` file loaded as read-only context. All seven concerns and seven skills condensed into clearly-headed sections. Adapted for Aider's `/architect` and `/code` mode workflow.
+
+**Gemini CLI** — Single `GEMINI.md` file at project root. All content as sections in one self-contained file.
+
+**JetBrains / Junie** — Single `.junie/guidelines.md` file, always loaded. All content as sections.
+
+**AGENTS.md** — Single `AGENTS.md` file following the vendor-neutral standard supported by 20+ tools. The most comprehensive single-file option. Use this as a universal fallback or when your tool is not otherwise listed.
+
+---
+
+## Advocacy-Specific Adaptations
+
+These instruction files differ from generic AI coding setups in several concrete ways:
+
+**Threat model** — Generic setups address common security concerns. These files encode the advocacy-specific three-adversary model: state surveillance using ag-gag statutes and device seizure, industry infiltration through social engineering, and AI model bias encoding speciesist defaults. Every security decision is evaluated against all three adversaries.
+
+**Domain language** — AI models default to generic or industry terminology. These files provide a ubiquitous language dictionary that prevents AI from substituting "livestock" for "farmed animal," "facility" for "slaughterhouse," or "project" for "campaign." This is enforced through explicit term lists and anti-synonym rules.
+
+**Bounded contexts** — Advocacy work spans four distinct contexts (investigation operations, public campaigns, coalition coordination, legal defense) that must not bleed into each other. Investigation data flowing into public campaign tooling is a legal liability. These files make that boundary explicit.
+
+**Identity protection** — Activist identity is a genuine safety concern, not a compliance checkbox. The privacy rules require pseudonymous identifiers, real deletion (not soft delete), and zero-knowledge architecture for whistleblower protection. The external contribution safety content ensures agents do not inadvertently expose organizational affiliation.
+
+**Emotional safety** — Developers working in this domain encounter traumatic content. The emotional safety concern encodes progressive disclosure patterns, configurable detail levels, and secondary trauma mitigation requirements — including the use of abstract test data (no graphic content in CI/CD pipelines).
+
+**Instruction file integrity** — AI instruction files are themselves an attack surface. The Rules File Backdoor attack embeds hidden Unicode characters that alter AI behavior invisibly. This repo runs a CI check (`scripts/check-unicode-integrity.py`) on every PR to detect such tampering.
+
+---
+
+## Open Paws Ecosystem Integration
+
+```
+structured-coding-with-ai  (this repo — canonical AI methodology)
+        |
+        +-- graze-cli          bundles instruction files into CLI binary
+        |
+        +-- desloppify         generates agent skill files from content
+        |
+        +-- gary               autonomous agent uses these as base instructions
+        |
+        +-- platform           copies claude-code/ into project root
+        |
+        +-- (all Open Paws     copy the relevant tool directory into
+             project repos)    their own project roots
+```
+
+The `CLAUDE.md` at the root of this repo documents the repo's own role in the ecosystem and its downstream consumers. When editing content here, verify the change does not break graze-cli bundling or desloppify skill generation.
 
 ---
 
 ## Customization
 
-These files are stack-agnostic starting points. They contain principles and methodology, not language-specific commands. After copying, add your own:
+After copying a tool directory, add your own:
 
 - Build and run commands
 - Linting and formatting configuration
-- Language-level code conventions
+- Language-level code conventions (naming, structure, idioms)
 - Project-specific entity names and architecture details
 - Tech stack details (frameworks, databases, deployment targets)
+- Domain-specific entity definitions beyond the advocacy baseline
 
-For Claude Code specifically, see `hooks-template.md` for setting up deterministic pre-commit, post-edit, and pre-push hooks with your own toolchain.
+These files are stack-agnostic starting points. They contain principles and methodology, not language-specific commands.
 
 ---
 
-## The 12 Tools
+## Adding a New Tool
 
-**Claude Code** -- `CLAUDE.md` at project root (under 60 lines), scoped rules in `.claude/rules/` with optional `paths:` frontmatter for file-targeted activation, process skills in `.claude/skills/` with YAML frontmatter (prefixed `advocacy-` to avoid shadowing global skills). Supports hooks for deterministic enforcement of formatting, linting, and security scanning.
+1. Create a new directory: `tool-name/`
+2. Implement all 7 concerns in the tool's native format
+3. Implement all 6 process skills in the tool's native format
+4. Add external contribution safety content (two-state identity model)
+5. Add a `README.md` inside the directory describing the files and copy commands
+6. Add a row to the table in this README
+7. Run `python scripts/check-unicode-integrity.py` before opening a PR
+8. Each tool must be independently authored for its format — do not copy content verbatim from another tool and relabel it
 
-**Cursor** -- `.cursorrules` at project root (always loaded), scoped rules in `.cursor/rules/*.mdc` using MDC format with four activation modes: Always Apply, Auto Attached (glob-triggered), Agent Requested (description-triggered), and Manual (user invokes with @).
+---
 
-**GitHub Copilot** -- The richest instruction hierarchy of any tool. `.github/copilot-instructions.md` (repo-wide), `.github/instructions/` (path-specific with `applyTo:`), `.github/prompts/` (reusable user-invocable workflows), `.github/chat-modes/` (persistent agent personas for advocacy review and requirements interviewing), `.github/skills/` (process skill packages).
+## Integrity Checking
 
-**Windsurf** -- `.windsurf/rules/*.md` with four trigger types: Always On, Model Decision, Glob, and Manual. Hard constraint of 6,000 characters per file and 12,000 characters combined. Always On files budgeted to ~8K total to leave headroom for contextually loaded files. Note: Windsurf generates persistent memories about your codebase -- review and clear regularly for sensitive projects.
+All instruction files are checked for hidden Unicode characters (the Rules File Backdoor attack) before every merge. Run the check locally before pushing any edits to instruction files:
 
-**Kilo Code** -- `.kilocode/rules/` with five mode-specific rule files (Ask, Architect, Code, Debug, Orchestrator), a Memory Bank (`brief.md`, `context.md`, `history.md`) for progressive context disclosure, seven concern files, and seven process skills in `.kilocode/skills/`.
+```bash
+python scripts/check-unicode-integrity.py
+```
 
-**Cline** -- `.clinerules/` directory with 14 Markdown files. Emphasizes Cline's Plan/Act paradigm: explore in Plan Mode before changing anything in Act Mode. All concern and skill content as separate rule files.
-
-**Roo Code** -- `.roomodes` JSON defining custom modes (Review and Interview) with tool restrictions and model assignments, plus `.roo/rules/` containing five mode-specific rule files (Architect, Code, Debug, Review, Interview), seven concern files, and seven skill files. Supports Boomerang Task delegation between modes.
-
-**Augment Code** -- `.augment/rules/*.md` with a `main.md` core file plus 13 concern and skill files. All files loaded as directory-based rules.
-
-**Aider** -- Single `CONVENTIONS.md` file loaded as read-only context. All seven concerns and seven skills condensed into clearly-headed sections. Adapted for Aider's `/architect` and `/code` mode workflow.
-
-**Gemini CLI** -- Single `GEMINI.md` file at project root. All content as sections in one self-contained file.
-
-**JetBrains / Junie** -- Single `.junie/guidelines.md` file, always loaded. All content as sections.
-
-**AGENTS.md** -- Single `AGENTS.md` file following the vendor-neutral standard supported by 20+ tools. The most comprehensive single-file option. Use this as a universal fallback or when your tool is not otherwise listed.
+CI runs this automatically on all PRs via GitHub Action.
 
 ---
 
 ## Source Material
 
-The content across all 12 tool sets was derived from a knowledge base covering: empirical research on AI-assisted development (code quality metrics, comprehension effects, failure patterns), software design principles (Ousterhout, Feathers, DDD), testing strategy (mutation testing, property-based testing, contract testing), git workflow for AI-generated code, and operational security for the animal advocacy domain. Each tool's content was independently authored to maximize use of its native format and activation mechanisms -- this is not a template applied 12 times.
+The content across all 12 tool sets was derived from a knowledge base covering: empirical research on AI-assisted development (code quality metrics, comprehension effects, failure patterns), software design principles (Ousterhout, Feathers, DDD), testing strategy (mutation testing, property-based testing, contract testing), git workflow for AI-generated code, and operational security for the animal advocacy domain. Each tool's content was independently authored to maximize use of its native format and activation mechanisms — this is not a template applied 12 times.
+
+---
+
+## License
+
+[MIT](LICENSE) — copy freely, modify for your context, no attribution required.


### PR DESCRIPTION
## Summary

- **README.md** — expanded with: status badge + ecosystem link, "why this exists" section explaining the three-adversary context, explicit section on advocacy-specific adaptations vs. generic AI setups, Open Paws ecosystem diagram showing how graze-cli/desloppify/gary/platform all depend on this repo, contributing guide for adding new tool directories, and integrity checking instructions. Existing content (copy commands, tool table, content coverage) preserved and lightly reorganized.

- **AGENTS.md** — new file for AI coding agents working inside this repo itself. Covers: one-paragraph summary of the meta nature of this repo (instruction files whose consumers are other AI agents), full annotated directory tree, task-to-file mapping table, content architecture explanation (7 concerns / 6 skills / 1 cross-cutting rule), security notes specific to instruction file integrity, quality gate commands, and known issues/TODOs surfaced from CLAUDE.md.

## What changed and why

The existing README was accurate but lacked: status classification, ecosystem context for new contributors, an explanation of *why* advocacy-specific adaptations are needed (not just *what* they are), and a contributing guide. The AGENTS.md did not exist.

## Test plan

- [ ] Verify README renders correctly on GitHub (tables, code blocks, headings)
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm all copy commands in README still match actual directory structure
- [ ] Confirm no speciesist language introduced (semgrep check will run in CI)
- [ ] Confirm no hidden Unicode characters (integrity check will run in CI)
