### PR TITLE
docs: standardize README to Open Paws ecosystem template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,120 @@
-# Structured Coding Library for Animal Advocacy
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/Open-Paws/structured-coding-with-ai)](https://github.com/Open-Paws/structured-coding-with-ai/commits/main)
+[![Integrity Check](https://github.com/Open-Paws/structured-coding-with-ai/actions/workflows/integrity-check.yml/badge.svg)](https://github.com/Open-Paws/structured-coding-with-ai/actions/workflows/integrity-check.yml)
+[![No Animal Violence](https://github.com/Open-Paws/structured-coding-with-ai/actions/workflows/no-animal-violence.yml/badge.svg)](https://github.com/Open-Paws/structured-coding-with-ai/actions/workflows/no-animal-violence.yml)
 
-> **Status: 🟢 Production** — actively maintained, all 12 tool directories stable, CI running on every PR.
-> Part of the [Open Paws](https://github.com/Open-Paws) developer ecosystem.
+# Structured Coding with AI — Open Paws
 
-Ready-to-use instruction file sets for 12 AI coding tools, designed for anyone building software for animal advocacy and liberation. Each tool directory is self-contained: copy it into your project root and your AI assistant immediately understands advocacy-domain constraints, security threat models, testing standards, and process workflows. No external dependencies, no shared config, no setup beyond copying files.
+Ready-to-use instruction file sets for 12 AI coding tools, built for developers working on animal advocacy software. Copy one directory into your project root and your AI assistant immediately understands the advocacy domain: three-adversary security threat model, activist identity protection, farmed animal terminology, and workflow standards. No external dependencies — just files.
 
----
+Maintained by [Open Paws](https://openpaws.ai), a 501(c)(3) nonprofit building AI infrastructure for the animal liberation movement.
 
-## Why This Exists
-
-Generic AI coding setups treat every codebase the same. Advocacy software is not generic. It operates under a three-adversary threat model (state surveillance, industry infiltration, AI model bias), handles data that is potential evidence under ag-gag statutes, and serves users who face genuine legal risk. The instruction files in this repo encode all of that — so every AI session starts with the right constraints rather than having to re-explain them.
-
-This repo is the **canonical source for AI coding methodology** across all Open Paws projects. It feeds two downstream consumers:
-- **[graze-cli](https://github.com/Open-Paws/graze-cli)** — bundles selected instruction files into its binary for advocacy-aware agentic coding
-- **[desloppify](https://github.com/Open-Paws/desloppify)** — generates agent skill files from the same content
-
-It also serves as curriculum for the Open Paws developer training bootcamp, where developers learn the 7 concerns and 6 process skills through hands-on project work.
+> [!NOTE]
+> This project is part of the [Open Paws](https://openpaws.ai) ecosystem — AI infrastructure for the animal liberation movement. [Explore the full platform →](https://github.com/Open-Paws)
 
 ---
 
-## Quick Start
+## Directory Structure
 
-Pick your tool. Copy the files into your project root.
+```
+structured-coding-with-ai/
+├── agents-md/          # AGENTS.md — vendor-neutral, 20+ tool support
+├── aider/              # CONVENTIONS.md
+├── augment-code/       # .augment/rules/ (14 files)
+├── claude-code/        # CLAUDE.md + .claude/rules/ + .claude/skills/ (17 files)
+├── cline/              # .clinerules/ (14 files)
+├── cursor/             # .cursorrules + .cursor/rules/ (14 files)
+├── gemini-cli/         # GEMINI.md
+├── github-copilot/     # .github/ instructions, prompts, chat modes (23 files)
+├── jetbrains-junie/    # .junie/guidelines.md
+├── kilo-code/          # .kilocode/rules/ + Memory Bank (21 files)
+├── roo-code/           # .roomodes + .roo/rules/ (19 files)
+├── windsurf/           # .windsurf/rules/ (14 files)
+└── scripts/            # Unicode integrity checker
+```
+
+---
+
+## Quickstart
+
+1. **Clone the repo**
+   ```bash
+   git clone https://github.com/Open-Paws/structured-coding-with-ai.git
+   ```
+
+2. **Pick your tool** from the table below and copy its directory into your project root
+
+3. **Claude Code example**
+   ```bash
+   cp claude-code/CLAUDE.md your-project/
+   cp claude-code/hooks-template.md your-project/
+   cp -r claude-code/.claude your-project/
+   ```
+
+4. **Add your project specifics** — build commands, language conventions, tech stack. The instruction files provide methodology; they do not replace project-specific setup.
+
+5. **Verify integrity** before committing instruction file edits
+   ```bash
+   python scripts/check-unicode-integrity.py
+   ```
+
+Full copy commands for every tool are listed in the [Tool Reference](#tool-reference) section below.
+
+---
+
+## Tools Covered
+
+| Tool | Directory | Files | Format |
+|------|-----------|------:|--------|
+| Claude Code | `claude-code/` | 17 | CLAUDE.md + scoped rules + skills + hooks template |
+| Cursor | `cursor/` | 14 | .cursorrules + .mdc files with 4 activation modes |
+| GitHub Copilot | `github-copilot/` | 23 | copilot-instructions.md + instructions + prompts + chat modes + skills |
+| Windsurf | `windsurf/` | 14 | .windsurf/rules/ with 4 trigger types, within 6K/12K char limits |
+| Kilo Code | `kilo-code/` | 21 | Mode files + Memory Bank + concern files + skills |
+| Cline | `cline/` | 14 | .clinerules/ with Plan/Act paradigm |
+| Roo Code | `roo-code/` | 19 | .roomodes JSON + mode rules + concern files + skills |
+| Augment Code | `augment-code/` | 14 | .augment/rules/ directory |
+| Aider | `aider/` | 1 | Single CONVENTIONS.md |
+| Gemini CLI | `gemini-cli/` | 1 | Single GEMINI.md |
+| JetBrains / Junie | `jetbrains-junie/` | 1 | Single .junie/guidelines.md, always loaded |
+| AGENTS.md | `agents-md/` | 1 | Vendor-neutral, supported by 20+ tools |
+| **Total** | | **140** | |
+
+---
+
+## Content Coverage
+
+Every tool directory covers the same material, adapted to its native format. Tools with multi-file support split content into separate files with appropriate activation triggers. Single-file tools condense everything into clearly-headed sections.
+
+### 7 Concerns (in every tool)
+
+- **Testing** — Spec-first generation, mutation testing, assertion quality over coverage percentage
+- **Security** — Three-adversary threat model (state surveillance, industry infiltration, AI model bias), zero-retention APIs, supply chain verification, device seizure preparation
+- **Privacy** — Activist identity protection, coalition data sharing, whistleblower protection, real deletion (not soft delete)
+- **Cost optimization** — Model routing, token budgets, prompt caching, vendor lock-in as movement risk
+- **Advocacy domain** — Ubiquitous language dictionary, bounded contexts for investigation ops / public campaigns / coalition coordination / legal defense
+- **Accessibility** — i18n from day one, offline-first, low-bandwidth, low-literacy design
+- **Emotional safety** — Progressive disclosure of traumatic content, configurable detail levels, secondary trauma mitigation for developers
+
+### 6 Process Skills (invoked on demand)
+
+- **git-workflow** — Issue-first GitHub workflow with worktree-per-task, plan-review-implement loop, desloppify gate
+- **testing-strategy** — Spec-first generation, five anti-patterns to avoid, mutation-guided improvement
+- **requirements-interview** — Structured stakeholder questions covering threat model, coalition needs, user safety
+- **plan-first-development** — Spec, design, decompose, implement one subtask at a time
+- **code-review** — Layered review pipeline, Ousterhout red flags, AI-specific failure patterns, advocacy data leak checks
+- **security-audit** — Advocacy threat model assessment, slopsquatting defense, prompt injection detection, MCP server security
+
+### External Contribution Safety
+
+All 12 directories include a two-state identity model: **advocacy mode** for Open Paws repos (full domain context active) and **neutral mode** for external open-source contributions (org identity suppressed, no advocacy framing in commits or PRs). This prevents AI agents from inadvertently identifying contributors or leaking organizational context when contributing to third-party projects.
+
+---
+
+## Tool Reference
+
+<details>
+<summary>Copy commands for all 12 tools</summary>
 
 ```bash
 # Claude Code
@@ -61,113 +154,42 @@ cp gemini-cli/GEMINI.md your-project/
 # JetBrains / Junie
 cp -r jetbrains-junie/.junie your-project/
 
-# AGENTS.md (universal, works with 20+ tools)
+# AGENTS.md (universal fallback, 20+ tool support)
 cp agents-md/AGENTS.md your-project/
 ```
 
-After copying, add your project's own build commands, linting configuration, language conventions, and tech stack details. These files provide principles and methodology — they do not replace project-specific setup.
+</details>
 
 ---
 
-## What's Included
+## Architecture
 
-| Tool | Directory | Files | Format Notes |
-|------|-----------|------:|--------------|
-| Claude Code | `claude-code/` | 17 | CLAUDE.md + 8 scoped rules + 7 skills + hooks template |
-| Cursor | `cursor/` | 14 | .cursorrules + 13 .mdc files with 4 activation modes |
-| GitHub Copilot | `github-copilot/` | 23 | copilot-instructions.md + 7 instructions + 6 prompts + 2 chat modes + 7 skills |
-| Windsurf | `windsurf/` | 14 | 14 .md files in .windsurf/rules/ with 4 trigger types, within 6K/12K char limits |
-| Kilo Code | `kilo-code/` | 21 | 5 mode files + 3 Memory Bank files + 7 concerns + 6 skills |
-| Cline | `cline/` | 14 | 14 .md files in .clinerules/ with Plan/Act paradigm |
-| Roo Code | `roo-code/` | 19 | .roomodes JSON + 5 mode rules + 7 concerns + 6 skills |
-| Augment Code | `augment-code/` | 14 | 14 .md files in .augment/rules/ |
-| Aider | `aider/` | 1 | Single CONVENTIONS.md with all content as sections |
-| Gemini CLI | `gemini-cli/` | 1 | Single GEMINI.md with all content as sections |
-| JetBrains / Junie | `jetbrains-junie/` | 1 | Single .junie/guidelines.md, always loaded |
-| AGENTS.md | `agents-md/` | 1 | Single vendor-neutral file, supported by 20+ tools |
-| **Total** | | **140** | |
+<details>
+<summary>How instruction files are structured across tools</summary>
 
----
+Each tool directory is self-contained and independently authored for its format — not a template applied 12 times.
 
-## Content Coverage
+**Multi-file tools** (Claude Code, Cursor, GitHub Copilot, Windsurf, Kilo Code, Cline, Roo Code, Augment Code) break content into separate files with activation triggers:
+- Always-on files: core methodology, ubiquitous language, security baseline
+- Conditionally loaded files: concern-specific rules triggered by file path or AI decision
+- On-demand files: process skill guides invoked explicitly
 
-Every tool covers the same material, adapted to its native format. Tools with multi-file support break content into separate files with appropriate activation triggers. Single-file tools condense everything into clearly-headed sections.
+**Single-file tools** (Aider, Gemini CLI, JetBrains/Junie, AGENTS.md) condense all 7 concerns and 6 skills into clearly-headed sections within one file.
 
-### 7 Concerns (present in every tool)
+**GitHub Copilot** has the richest hierarchy: `copilot-instructions.md` (repo-wide), `instructions/` (path-specific with `applyTo:`), `prompts/` (reusable workflows), `chat-modes/` (persistent agent personas), and `skills/`.
 
-- **Testing** — Assertion quality, spec-first generation, property-based testing, mutation testing, adversarial input testing
-- **Security** — Zero-retention APIs, ag-gag legal exposure, supply chain verification, device seizure preparation, three-adversary threat model
-- **Privacy** — Activist identity protection, coalition data sharing, whistleblower protection, GDPR/CCPA compliance, data minimization
-- **Cost optimization** — Model routing, token budgets, prompt caching, vendor lock-in as movement risk, nonprofit budget allocation
-- **Advocacy domain** — Ubiquitous language dictionary, bounded contexts (investigation ops / public campaigns / coalition coordination / legal defense), entity definitions
-- **Accessibility** — i18n, offline-first, low-bandwidth, low-literacy design, mesh networking, device seizure resilience
-- **Emotional safety** — Progressive disclosure of traumatic content, configurable detail levels, content warnings, secondary trauma mitigation
+**Roo Code** uses `.roomodes` JSON to define custom modes (Review, Interview) with tool restrictions and model assignments per mode.
 
-### 6 Process Skills (workflow guides invoked on demand)
+**Windsurf** enforces hard limits of 6,000 characters per file and 12,000 characters combined across loaded files. Always-on files are budgeted to ~8K total to leave headroom for conditionally loaded files.
 
-- **git-workflow** — Issue-first GitHub workflow: worktree-per-task, plan-then-review-then-implement loops, desloppify gate, PR monitoring until merged
-- **testing-strategy** — Spec-first generation, five anti-patterns to avoid (snapshot trap, mock everything, happy path only, test-after-commit, coverage theater), mutation-guided improvement
-- **requirements-interview** — Structured stakeholder questions covering threat model, coalition needs, user safety, budget constraints
-- **plan-first-development** — Spec, design, decompose, implement one subtask at a time, generation-then-comprehension pattern
-- **code-review** — Layered review pipeline, Ousterhout red flags, AI-specific failure patterns, advocacy-specific data leak checks
-- **security-audit** — Advocacy threat model assessment, slopsquatting defense, prompt injection / rules file backdoor detection, MCP server security
+**Integrity protection**: All instruction files are checked on every PR for hidden Unicode characters (the Rules File Backdoor attack). Run `python scripts/check-unicode-integrity.py` locally before pushing any edits to instruction files.
 
-### External Contribution Safety
-
-All 12 tool directories include external contribution safety content. This teaches the two-state identity model: **advocacy mode** for Open Paws repos (full domain context, movement terminology, seven concerns active), and **neutral mode** for external open-source repos (org identity suppressed, commit hygiene enforced, no advocacy-specific framing in commits or PRs). This prevents AI agents from inadvertently identifying contributors or leaking organizational context when contributing to third-party projects.
-
----
-
-## Tool-by-Tool Reference
-
-**Claude Code** — `CLAUDE.md` at project root (under 60 lines), scoped rules in `.claude/rules/` with optional `paths:` frontmatter for file-targeted activation, process skills in `.claude/skills/` with YAML frontmatter (prefixed `advocacy-` to avoid shadowing global skills). Supports hooks for deterministic enforcement of formatting, linting, and security scanning. See `hooks-template.md` for hook configuration.
-
-**Cursor** — `.cursorrules` at project root (always loaded), scoped rules in `.cursor/rules/*.mdc` using MDC format with four activation modes: Always Apply, Auto Attached (glob-triggered), Agent Requested (description-triggered), and Manual (user invokes with @).
-
-**GitHub Copilot** — The richest instruction hierarchy of any tool covered. `.github/copilot-instructions.md` (repo-wide), `.github/instructions/` (path-specific with `applyTo:`), `.github/prompts/` (reusable user-invocable workflows), `.github/chat-modes/` (persistent agent personas for advocacy review and requirements interviewing), `.github/skills/` (process skill packages).
-
-**Windsurf** — `.windsurf/rules/*.md` with four trigger types: Always On, Model Decision, Glob, and Manual. Hard constraint of 6,000 characters per file and 12,000 characters combined. Always On files budgeted to ~8K total to leave headroom for contextually loaded files. Note: Windsurf generates persistent memories about your codebase — review and clear these regularly for sensitive projects.
-
-**Kilo Code** — `.kilocode/rules/` with five mode-specific rule files (Ask, Architect, Code, Debug, Orchestrator), a Memory Bank (`brief.md`, `context.md`, `history.md`) for progressive context disclosure, seven concern files, and seven process skills in `.kilocode/skills/`.
-
-**Cline** — `.clinerules/` directory with 14 Markdown files. Emphasizes Cline's Plan/Act paradigm: explore in Plan Mode before changing anything in Act Mode. All concern and skill content as separate rule files.
-
-**Roo Code** — `.roomodes` JSON defining custom modes (Review and Interview) with tool restrictions and model assignments, plus `.roo/rules/` containing five mode-specific rule files (Architect, Code, Debug, Review, Interview), seven concern files, and seven skill files. Supports Boomerang Task delegation between modes.
-
-**Augment Code** — `.augment/rules/*.md` with a `main.md` core file plus 13 concern and skill files. All files loaded as directory-based rules.
-
-**Aider** — Single `CONVENTIONS.md` file loaded as read-only context. All seven concerns and seven skills condensed into clearly-headed sections. Adapted for Aider's `/architect` and `/code` mode workflow.
-
-**Gemini CLI** — Single `GEMINI.md` file at project root. All content as sections in one self-contained file.
-
-**JetBrains / Junie** — Single `.junie/guidelines.md` file, always loaded. All content as sections.
-
-**AGENTS.md** — Single `AGENTS.md` file following the vendor-neutral standard supported by 20+ tools. The most comprehensive single-file option. Use this as a universal fallback or when your tool is not otherwise listed.
-
----
-
-## Advocacy-Specific Adaptations
-
-These instruction files differ from generic AI coding setups in several concrete ways:
-
-**Threat model** — Generic setups address common security concerns. These files encode the advocacy-specific three-adversary model: state surveillance using ag-gag statutes and device seizure, industry infiltration through social engineering, and AI model bias encoding speciesist defaults. Every security decision is evaluated against all three adversaries.
-
-**Domain language** — AI models default to generic or industry terminology. These files provide a ubiquitous language dictionary that prevents AI from substituting "livestock" for "farmed animal," "facility" for "slaughterhouse," or "project" for "campaign." This is enforced through explicit term lists and anti-synonym rules.
-
-**Bounded contexts** — Advocacy work spans four distinct contexts (investigation operations, public campaigns, coalition coordination, legal defense) that must not bleed into each other. Investigation data flowing into public campaign tooling is a legal liability. These files make that boundary explicit.
-
-**Identity protection** — Activist identity is a genuine safety concern, not a compliance checkbox. The privacy rules require pseudonymous identifiers, real deletion (not soft delete), and zero-knowledge architecture for whistleblower protection. The external contribution safety content ensures agents do not inadvertently expose organizational affiliation.
-
-**Emotional safety** — Developers working in this domain encounter traumatic content. The emotional safety concern encodes progressive disclosure patterns, configurable detail levels, and secondary trauma mitigation requirements — including the use of abstract test data (no graphic content in CI/CD pipelines).
-
-**Instruction file integrity** — AI instruction files are themselves an attack surface. The Rules File Backdoor attack embeds hidden Unicode characters that alter AI behavior invisibly. This repo runs a CI check (`scripts/check-unicode-integrity.py`) on every PR to detect such tampering.
-
----
-
-## Open Paws Ecosystem Integration
+**Ecosystem position**: This repo is the canonical AI methodology source for all Open Paws projects. It feeds two downstream consumers:
+- [graze-cli](https://github.com/Open-Paws/graze-cli) — bundles selected instruction files into its binary
+- [desloppify](https://github.com/Open-Paws/desloppify) — generates agent skill files from the same content
 
 ```
-structured-coding-with-ai  (this repo — canonical AI methodology)
+structured-coding-with-ai  (canonical AI methodology)
         |
         +-- graze-cli          bundles instruction files into CLI binary
         |
@@ -177,60 +199,60 @@ structured-coding-with-ai  (this repo — canonical AI methodology)
         |
         +-- platform           copies claude-code/ into project root
         |
-        +-- (all Open Paws     copy the relevant tool directory into
+        +-- (all Open Paws     copy relevant tool directory into
              project repos)    their own project roots
 ```
 
-The `CLAUDE.md` at the root of this repo documents the repo's own role in the ecosystem and its downstream consumers. When editing content here, verify the change does not break graze-cli bundling or desloppify skill generation.
+</details>
 
 ---
 
-## Customization
+## Documentation
 
-After copying a tool directory, add your own:
-
-- Build and run commands
-- Linting and formatting configuration
-- Language-level code conventions (naming, structure, idioms)
-- Project-specific entity names and architecture details
-- Tech stack details (frameworks, databases, deployment targets)
-- Domain-specific entity definitions beyond the advocacy baseline
-
-These files are stack-agnostic starting points. They contain principles and methodology, not language-specific commands.
+- [Claude Code directory README](claude-code/README.md) — file-by-file description and copy commands
+- [scripts/check-unicode-integrity.py](scripts/check-unicode-integrity.py) — integrity checker for instruction files
+- [Open Paws developer docs](https://openpaws.ai) — platform documentation
 
 ---
 
-## Adding a New Tool
+## Contributing
 
-1. Create a new directory: `tool-name/`
+The most valuable contribution is a new tool directory. If you use an AI coding tool not listed here, add it:
+
+1. Create `tool-name/` at the repo root
 2. Implement all 7 concerns in the tool's native format
 3. Implement all 6 process skills in the tool's native format
 4. Add external contribution safety content (two-state identity model)
-5. Add a `README.md` inside the directory describing the files and copy commands
-6. Add a row to the table in this README
+5. Add a `README.md` inside the directory with file descriptions and copy commands
+6. Add a row to the tools table in this README
 7. Run `python scripts/check-unicode-integrity.py` before opening a PR
 8. Each tool must be independently authored for its format — do not copy content verbatim from another tool and relabel it
 
+Each tool must cover advocacy-domain content: farmed animal terminology, the three-adversary security model, activist identity protection, and emotional safety for developers. Generic instruction files without advocacy context do not meet the bar for this repo.
+
 ---
 
-## Integrity Checking
+## License and Acknowledgments
 
-All instruction files are checked for hidden Unicode characters (the Rules File Backdoor attack) before every merge. Run the check locally before pushing any edits to instruction files:
+[MIT](LICENSE) — Copyright (c) 2024–2026 Open Paws. Copy freely, modify for your context, no attribution required.
 
-```bash
-python scripts/check-unicode-integrity.py
+Content across all 12 tool sets was derived from a knowledge base covering empirical research on AI-assisted development, software design principles (Ousterhout, Feathers, DDD), testing strategy, git workflow for AI-generated code, and operational security for the animal advocacy domain.
+
+---
+
+```yaml
+tech_stack: [markdown, python]
+project_status: stable
+difficulty: beginner
+skill_tags: [ai-coding, instruction-files, animal-advocacy, security, developer-tooling]
+related_repos:
+  - https://github.com/Open-Paws/graze-cli
+  - https://github.com/Open-Paws/desloppify
+  - https://github.com/Open-Paws/gary
+  - https://github.com/Open-Paws/platform
+  - https://github.com/Open-Paws/no-animal-violence
 ```
 
-CI runs this automatically on all PRs via GitHub Action.
-
 ---
 
-## Source Material
-
-The content across all 12 tool sets was derived from a knowledge base covering: empirical research on AI-assisted development (code quality metrics, comprehension effects, failure patterns), software design principles (Ousterhout, Feathers, DDD), testing strategy (mutation testing, property-based testing, contract testing), git workflow for AI-generated code, and operational security for the animal advocacy domain. Each tool's content was independently authored to maximize use of its native format and activation mechanisms — this is not a template applied 12 times.
-
----
-
-## License
-
-[MIT](LICENSE) — copy freely, modify for your context, no attribution required.
+[Donate](https://openpaws.ai/donate) · [Discord](https://discord.gg/openpaws) · [openpaws.ai](https://openpaws.ai) · [Volunteer](https://openpaws.ai/volunteer)


### PR DESCRIPTION
## Summary

- Restructures README to follow the Open Paws ecosystem template: badge row, TL;DR, Open Paws callout, directory tree, quickstart, tools table, content coverage, collapsible architecture section, contributing guide, license, metadata block, and footer
- Updates file count from 137 to 140 (accurate count from current table)
- Moves the copy commands for all tools into a collapsible `<details>` block to reduce visual noise while keeping them accessible
- Adds metadata YAML block (`tech_stack`, `project_status`, `difficulty`, `skill_tags`, `related_repos`) at the foot of the file

## What was preserved

All substantive content from the previous README is retained — tool descriptions, concern summaries, skill summaries, external contribution safety explanation, ecosystem diagram, integrity check instructions, and source material acknowledgment. This is a structural reorganization, not a content reduction.

## Test plan

- [ ] Verify all 12 tool directories are listed in the tools table
- [ ] Verify copy commands in the collapsible section match actual directory/file names in the repo
- [ ] Verify CI badges resolve correctly after merge
- [ ] Verify the `<details>` blocks render correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Restructured README with improved organization and navigation
  * Added new Directory Structure, Tools Covered table, and Architecture sections
  * Enhanced Quickstart and Content Coverage guidance
  * Introduced External Contribution Safety section
  * Updated project metadata and contributing instructions
  * Added status badges and external resource links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->