### PR TITLE
chore(docs): rename open-paws-strategy → Open-Paws/context refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ Ready-to-use AI coding instruction files for 12 tools, tailored for animal advoc
 **Unicode integrity (CI):** A CI action checks all instruction files for hidden Unicode characters (Rules File Backdoor attack). The `scripts/check-unicode-integrity.py` script is the underlying tool.
 
 **Strategy references:**
-- `open-paws-strategy/ecosystem/repos.md` — structured-coding-with-ai entry with full breakdown
-- `open-paws-strategy/closed-decisions.md` — 2026-04-01 external contribution safety decision
-- `open-paws-strategy/programs/developer-training-pipeline/guild/operations.md` — bootcamp curriculum context
+- `context/ecosystem/repos.md` — structured-coding-with-ai entry with full breakdown
+- `context/decisions.md` — 2026-04-01 external contribution safety decision
+- `context/programs/developer-training-pipeline/guild/operations.md` — bootcamp curriculum context
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
The org context repo was renamed from `open-paws-strategy` to `context`. This repo's CLAUDE.md / AGENTS.md still references the old name, plus the renamed `decisions.md` (was `settled-decisions.md`). The `gh api` strategy-fetch blocks currently 404.

## What changed
- `Open-Paws/open-paws-strategy` → `Open-Paws/context`
- `settled-decisions.md` → `decisions.md`
- `closed-decisions.md` → `decisions.md`

## Why
Generated as part of the canonical-rename drive. The strategy-fetch code blocks were broken; agents fetching fresh strategy state would 404 on every call. No code or behavior changes — agent/AI documentation only.