### PR TITLE
fix(skills): prefer fixture logs in candidate signal intake (fixes #37)

### DIFF
--- a/claude-code/.claude/skills/unblock/SKILL.md
+++ b/claude-code/.claude/skills/unblock/SKILL.md
@@ -30,10 +30,16 @@ Read these every fire (auto-load via `InstructionsLoaded`; cite by name in any f
 ### 1. Find the input
 
 ```bash
-if ls ~/.claude/fixture-logs/*.md &>/dev/null 2>&1; then
-  LATEST=$(ls -t ~/.claude/fixture-logs/*.md 2>/dev/null | head -1)
+FIXTURE_LATEST=$(ls -t ~/.claude/fixture-logs/*.md 2>/dev/null | head -1)
+ORCH_LATEST=$(ls -t ~/.claude/orchestrator-log/run-*.md 2>/dev/null | head -1)
+if [ -z "$FIXTURE_LATEST" ]; then
+  LATEST="$ORCH_LATEST"
+elif [ -z "$ORCH_LATEST" ]; then
+  LATEST="$FIXTURE_LATEST"
+elif [ "$FIXTURE_LATEST" -nt "$ORCH_LATEST" ]; then
+  LATEST="$FIXTURE_LATEST"
 else
-  LATEST=$(ls -t ~/.claude/orchestrator-log/run-*.md 2>/dev/null | head -1)
+  LATEST="$ORCH_LATEST"
 fi
 ```
 

--- a/claude-code/.claude/skills/unblock/SKILL.md
+++ b/claude-code/.claude/skills/unblock/SKILL.md
@@ -30,7 +30,11 @@ Read these every fire (auto-load via `InstructionsLoaded`; cite by name in any f
 ### 1. Find the input
 
 ```bash
-LATEST=$(ls -t ~/.claude/orchestrator-log/run-*.md 2>/dev/null | head -1)
+if ls ~/.claude/fixture-logs/*.md &>/dev/null 2>&1; then
+  LATEST=$(ls -t ~/.claude/fixture-logs/*.md 2>/dev/null | head -1)
+else
+  LATEST=$(ls -t ~/.claude/orchestrator-log/run-*.md 2>/dev/null | head -1)
+fi
 ```
 
 If `LATEST` exists AND mtime within last 30 minutes:


### PR DESCRIPTION
Prefer fixture logs over latest orchestrator log to enable deterministic verification. Fixes structured-coding-with-ai#37.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log discovery behavior to prioritize fixture logs when available, with fallback to previous log selection method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->