### PR TITLE
chore(docs): drop refs to deleted repos (graze-cli, gary)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,7 @@ This repo contains ready-to-use AI coding instruction files for 12 tools, tailor
 
 This repo is unusual: it is instruction files whose consumers are other AI agents. A change to `claude-code/.claude/rules/security.md` affects every Claude Code session across all Open Paws projects that have copied those files. A change to `agents-md/AGENTS.md` affects 20+ AI tools. Treat content edits with the same care you would treat changes to a shared library used in production.
 
-Two downstream consumers depend on this repo's content directly:
-- **graze-cli** — bundles selected instruction files into its binary; content changes require verifying the bundled output still renders correctly
+One downstream consumer depends on this repo's content directly:
 - **desloppify** — generates agent skill files from the same content; structural changes to skill files may break the generation pipeline
 
 ---
@@ -97,7 +96,7 @@ The most common failure modes in this repo are:
 - Introducing synonyms for established domain terms (see advocacy-domain language dictionary in `CLAUDE.md`)
 - Adding graphic investigation content to example prompts or test scenarios (violates emotional-safety concern)
 - Copying content across tool directories rather than independently authoring for each format
-- Edits that break the structural assumptions of downstream consumers (graze-cli bundling, desloppify skill generation)
+- Edits that break the structural assumptions of downstream consumers (desloppify skill generation)
 - Hidden Unicode characters introduced through copy-paste from external sources
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Ready-to-use AI coding instruction files for 12 tools, tailored for animal advoc
 
 ## Organizational Context
 
-**Role in flywheel:** This repo is the canonical source for AI coding methodology across all Open Paws projects. It feeds two downstream consumers: `graze-cli` bundles selected guides into its binary, and `desloppify` generates agent skill files from the same content. It is also curriculum content for the bootcamp — developers learn these 7 concerns and 6 process skills through the training pipeline.
+**Role in flywheel:** This repo is the canonical source for AI coding methodology across all Open Paws projects. Its primary downstream consumer is `desloppify`, which generates agent skill files from this content. It is also curriculum content for the bootcamp — developers learn these 7 concerns and 6 process skills through the training pipeline.
 
 **Layer:** 1 — Strengthen. Lever: Strengthen.
 
@@ -126,7 +126,7 @@ For tool-specific AI coding instructions, copy the corresponding directory from 
 
 All 7 always apply. Critical for this repo:
 
-1. **Testing** — Content changes must not break the downstream consumers (graze-cli bundling, desloppify skill generation). Verify content renders correctly in the target tool's format
+1. **Testing** — Content changes must not break the downstream consumers (desloppify skill generation). Verify content renders correctly in the target tool's format
 2. **Security** — Instruction file integrity is a first-class concern. Hidden Unicode in instruction files is the Rules File Backdoor attack. Every PR runs the Unicode check
 3. **Privacy** — No activist data or operational details in example code or sample prompts
 4. **Cost** — Instruction files are loaded into every AI session that uses them. Keep them lean — every token counts at scale across the bootcamp

--- a/README.md
+++ b/README.md
@@ -185,18 +185,13 @@ Each tool directory is self-contained and independently authored for its format 
 
 **Integrity protection**: All instruction files are checked on every PR for hidden Unicode characters (the Rules File Backdoor attack). Run `python scripts/check-unicode-integrity.py` locally before pushing any edits to instruction files.
 
-**Ecosystem position**: This repo is the canonical AI methodology source for all Open Paws projects. It feeds two downstream consumers:
-- [graze-cli](https://github.com/Open-Paws/graze-cli) — bundles selected instruction files into its binary
+**Ecosystem position**: This repo is the canonical AI methodology source for all Open Paws projects. Its primary downstream consumer:
 - [desloppify](https://github.com/Open-Paws/desloppify) — generates agent skill files from the same content
 
 ```
 structured-coding-with-ai  (canonical AI methodology)
         |
-        +-- graze-cli          bundles instruction files into CLI binary
-        |
         +-- desloppify         generates agent skill files from content
-        |
-        +-- gary               autonomous agent uses these as base instructions
         |
         +-- platform           copies claude-code/ into project root
         |
@@ -251,9 +246,7 @@ project_status: stable
 difficulty: beginner
 skill_tags: [ai-coding, instruction-files, animal-advocacy, security, developer-tooling]
 related_repos:
-  - https://github.com/Open-Paws/graze-cli
   - https://github.com/Open-Paws/desloppify
-  - https://github.com/Open-Paws/gary
   - https://github.com/Open-Paws/platform
   - https://github.com/Open-Paws/no-animal-violence
 ```


### PR DESCRIPTION
Open-Paws/graze-cli and Open-Paws/gary are being deleted. This repo's canonical-methodology framing referenced graze-cli as a downstream bundling consumer and gary as an integration point — strip those.

- `AGENTS.md` — "two downstream consumers" → "one downstream consumer"; drop graze-cli bundling from review-time failure modes
- `README.md` — drop graze-cli + gary from ecosystem-position diagram and related_repos metadata
- `CLAUDE.md` — same downstream-consumers framing fix; drop graze-cli bundling from the testing concern

Closes #44